### PR TITLE
Fix Codecov Token in README and CI Configuration

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -41,5 +41,5 @@ jobs:
           source /home/olender/firedrakes/2024_07_19/firedrake/bin/activate
           mpiexec -n 6 pytest --cov-report=xml --cov-append --cov=spyro test_parallel/test_fwi.py
     - name: Uploading coverage to Codecov
-      run: export CODECOV_TOKEN="057ec853-d7ea-4277-819b-0c5ea2f9ff57" && bash <(curl -s https://codecov.io/bash)
+      run: export CODECOV_TOKEN="6cd21147-54f7-4b77-94ad-4b138053401d" && bash <(curl -s https://codecov.io/bash)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![DOI](https://zenodo.org/badge/318542339.svg)](https://zenodo.org/badge/latestdoi/318542339)
 [![Python tests](https://github.com/NDF-Poli-USP/spyro/actions/workflows/python-tests.yml/badge.svg)](https://github.com/NDF-Poli-USP/spyro/actions/workflows/python-tests.yml)
-[![codecov](https://codecov.io/gh/Olender/spyro-1/graph/badge.svg?token=69M30UMRFD)](https://codecov.io/gh/Olender/spyro-1)
+[![codecov](https://codecov.io/gh/NDF-Poli-USP/spyro/graph/badge.svg?token=8NM4N4N7YW)](https://codecov.io/gh/NDF-Poli-USP/spyro)
 
 spyro: seismic parallel inversion and reconstruction optimization framework
 ============================================


### PR DESCRIPTION
This PR addresses an issue with the Codecov token configuration, which was still referencing my fork. The token has been updated in both the README file and the CI YML file to ensure proper coverage reporting.

### Changes

- Updated Codecov token in `README.md`
- Updated Codecov token in CI configuration file (`.github/workflows/python-tests.yml`)