### PR TITLE
Fixing bug that causes tests to fail 

### DIFF
--- a/spyro/solvers/backward_time_integration.py
+++ b/spyro/solvers/backward_time_integration.py
@@ -55,7 +55,7 @@ def backward_wave_propagator_no_pml(Wave_obj, dt=None):
     filename, file_extension = temp_filename.split(".")
     output_filename = "backward." + file_extension
 
-    output = fire.VTKFile(output_filename, comm=comm.comm)
+    output = fire.VTKFile(output_filename)
     comm.comm.barrier()
 
     X = fire.Function(Wave_obj.function_space)
@@ -184,7 +184,7 @@ def mixed_space_backward_wave_propagator(Wave_obj, dt=None):
     filename, file_extension = temp_filename.split(".")
     output_filename = "backward." + file_extension
 
-    output = fire.VTKFile(output_filename, comm=comm.comm)
+    output = fire.VTKFile(output_filename)
     comm.comm.barrier()
 
     X = Wave_obj.X


### PR DESCRIPTION
This bug happens when you only run the integration tests instead of every test. The mpi gets stuck on file creation. The VTK file should have been generated with the default communicator not comm.comm.