### PR TITLE
Share .coverage results across CI jobs

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -61,6 +61,17 @@ jobs:
         ./cleanup.sh
         python3 -m pytest -n 8 --cov-report=xml --cov=spyro tests/on_one_core/ --skip-slow --durations=10
 
+    - name: Rename coverage file
+      # This is necessary because upload-artifact doesnt recognize hidden files
+      run: |
+        cp .coverage cov-data
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage
+        path: cov-data
+
     - name: Post-run cleanup
       if: always()
       run: find . -delete
@@ -106,6 +117,16 @@ jobs:
                ~/.cache/tsfc \
                .pytest_cache
         find . -name '*.pkl' -delete || true
+
+    # - name: Download coverage data
+    #   uses: actions/download-artifact@v4
+    #   with:
+    #     name: coverage
+
+    # - name: Rename coverage file
+    #   # This is necessary because .coverage was renamed since upload-artifact doesnt recognize hidden files
+    #   run: |
+    #     cp cov-data .coverage
 
     - name: Running serial slow tests
       run: |

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -118,15 +118,15 @@ jobs:
                .pytest_cache
         find . -name '*.pkl' -delete || true
 
-    # - name: Download coverage data
-    #   uses: actions/download-artifact@v4
-    #   with:
-    #     name: coverage
+    - name: Download coverage data
+      uses: actions/download-artifact@v4
+      with:
+        name: coverage
 
-    # - name: Rename coverage file
-    #   # This is necessary because .coverage was renamed since upload-artifact doesnt recognize hidden files
-    #   run: |
-    #     cp cov-data .coverage
+    - name: Rename coverage file
+      # This is necessary because .coverage was renamed since upload-artifact doesnt recognize hidden files
+      run: |
+        cp cov-data .coverage
 
     - name: Running serial slow tests
       run: |


### PR DESCRIPTION
Fix coverage results with upload-artifact and download-artifact actions