### PR TITLE
Add backup-tags workflow

### DIFF
--- a/.github/workflows/backup-tags.yaml
+++ b/.github/workflows/backup-tags.yaml
@@ -1,0 +1,32 @@
+name: Automatically Create Backup Tags
+
+on:
+  push:
+    branches:
+      - main
+
+# This is required to push the tags from the workflow
+permissions:
+  contents: write
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create tag
+        run: |
+          TAG="backup-$(git rev-parse --short HEAD)-$(date +%4Y_%m_%d_z%Z_%H_%M_%S)"
+
+          echo "Creating tag: $TAG"
+
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
The workflow created in this PR creates and pushes a tag on the latest commit on every push to the main branch. The created tag has the name `backup-<hash>-<date>`, where `<hash>` is the hash of the commit that the tag points to, and `<date>` is the date and time at the moment when the action is run.

The motivation for this is so that in the case of an accidental push to main where the commit history is altered, the backup tags will still reference the correct commits, keeping them from being discarded, and allowing the correct commit history to be restored.

These tags do not replace the tags which indicate the versions of the code (with the format `v.X.Y.Z`).