### PR TITLE
Olender time interpolator for shots

### DIFF
--- a/spyro/io/time_io.py
+++ b/spyro/io/time_io.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 class Read_time_axis:
     def __init__(self):
         # some default parameters we might use in the future
@@ -41,3 +44,72 @@ class Read_time_axis:
         if value != "central_difference":
             raise ValueError(f"The time integrator of {value} is not implemented yet")
         self._time_integrator = value
+
+
+def interpolate_time_series(
+    values,
+    target_dt,
+    initial_time=None,
+    final_time=None,
+):
+    """Resample receiver data from one time grid onto another.
+
+    Parameters
+    ----------
+    values : array_like
+        Time series data stored as ``(time, receiver)`` or ``(time,)``.
+    target_dt : float
+        Desired timestep.
+    initial_time : float
+        Starting time of the simulation.
+    final_time : float
+        Final time of the simulation
+
+    Returns
+    -------
+    numpy.ndarray
+        Data interpolated onto the target time grid.
+    """
+    if target_dt <= 0.0:
+        raise ValueError("target_dt must be positive.")
+
+    if initial_time is None:
+        initial_time = 0.0
+    if final_time is None:
+        raise ValueError("final_time must be provided.")
+    if final_time < initial_time:
+        raise ValueError("final_time must be greater than or equal to initial_time.")
+
+    array = np.asarray(values, dtype=float)
+    input_was_1d = array.ndim == 1
+    if array.ndim == 1:
+        array = array[:, np.newaxis]
+    elif array.ndim != 2:
+        raise ValueError("Time series interpolation expects a 1D or 2D array.")
+
+    num_source_steps = array.shape[0]
+    if num_source_steps <= 1:
+        raise ValueError("values must contain at least two time samples.")
+
+    source_dt = (final_time - initial_time) / (num_source_steps - 1)
+
+    target_num_steps = int(np.round((final_time - initial_time) / target_dt)) + 1
+    if target_num_steps <= 1:
+        raise ValueError("target_dt and time interval produce too few target samples.")
+
+    source_times = initial_time + np.arange(num_source_steps) * source_dt
+    target_times = initial_time + np.arange(target_num_steps) * target_dt
+
+    interpolated = np.empty((target_num_steps, array.shape[1]), dtype=float)
+    for receiver_id in range(array.shape[1]):
+        interpolated[:, receiver_id] = np.interp(
+            target_times,
+            source_times,
+            array[:, receiver_id],
+            left=array[0, receiver_id],
+            right=array[-1, receiver_id],
+        )
+
+    if input_was_1d:
+        return interpolated[:, 0]
+    return interpolated

--- a/spyro/plots/__init__.py
+++ b/spyro/plots/__init__.py
@@ -1,5 +1,5 @@
 from .plots import plot_shots, plot_mesh_sizes, plot_model, plot_function, plot_model_in_p1
-from .plots import debug_plot, debug_pvd
+from .plots import debug_plot, debug_pvd, plot_receiver_response
 
 __all__ = [
     "plot_shots",
@@ -9,4 +9,5 @@ __all__ = [
     "debug_plot",
     "debug_pvd",
     "plot_model_in_p1",
+    "plot_receiver_response",
 ]

--- a/spyro/plots/plots.py
+++ b/spyro/plots/plots.py
@@ -10,7 +10,7 @@ from ..utils import change_scalar_field_resolution
 from ..tools.version_control import is_firedrake_new
 plt.rcParams.update({"font.family": "serif"})
 plt.rcParams['text.latex.preamble'] = r'\usepackage{bm} \usepackage{amsmath}'
-__all__ = ["plot_shots"]
+__all__ = ["plot_shots", "plot_receiver_response"]
 
 
 if is_firedrake_new() is False:
@@ -481,3 +481,85 @@ def plot_model_in_p1(Wave_object, dx=0.01, filename="model.png", abc_points=None
     new_wave_obj.set_initial_velocity_model(conditional=Wave_object.initial_velocity_model)
 
     return plot_model(new_wave_obj, filename=filename, abc_points=abc_points, show=show, flip_axis=flip_axis)
+
+
+def plot_receiver_response(
+    receiver_data,
+    final_time,
+    show=False,
+    filename=None,
+    receiver_id_for_title=None,
+    hold=False,
+    color=None,
+    name=None,
+    **plot_kwargs,
+):
+    """Plot the time-series response for a single receiver.
+
+    Parameters
+    ----------
+    receiver_data : np.array
+        Receiver data to plot.
+    show : bool, optional
+        Whether to display the plot interactively. Default is False.
+    filename : str, optional
+        If provided, save the plot to this file.
+    hold : bool, optional
+        If True, plot on the current axes so multiple receivers can be
+        overlaid in sequence. Default is False.
+    color : str, optional
+        Line color to use when plotting. If None and hold is True, a random
+        color is selected.
+    name : str, optional
+        Label to use in the legend. When provided, the plot is added to the
+        legend so multiple held traces can be identified.
+    **plot_kwargs
+        Any additional keyword arguments accepted by matplotlib.axes.Axes.plot.
+
+    Returns
+    -------
+    None
+        The function creates the plot and displays it.
+    """
+    num_times = len(receiver_data)
+
+    time_vector = np.linspace(0.0, final_time, num_times)
+
+    if hold is False:
+        plt.close()
+        fig, axes = plt.subplots(figsize=(10, 4))
+    else:
+        fig = plt.gcf()
+        axes = plt.gca()
+        if fig.get_axes() == []:
+            fig, axes = plt.subplots(figsize=(10, 4))
+
+    if color is None and hold:
+        color_choices = plt.rcParams["axes.prop_cycle"].by_key().get("color", [None])
+        color = np.random.choice(color_choices)
+
+    line_kwargs = dict(plot_kwargs)
+    line_kwargs.setdefault("linewidth", 2)
+    line_kwargs.setdefault("color", color)
+    if name is not None:
+        line_kwargs.setdefault("label", name)
+
+    axes.plot(time_vector, receiver_data, **line_kwargs)
+    axes.set_xlabel("time (s)", fontsize=18)
+    axes.set_ylabel("receiver response", fontsize=18)
+    if receiver_id_for_title is not None:
+        axes.set_title(f"Receiver ID{receiver_id_for_title} data.", fontsize=22)
+    else:
+        axes.set_title("Receiver data.", fontsize=22)
+    if line_kwargs.get("label") is not None:
+        axes.legend()
+    axes.tick_params(axis="both", labelsize=18)
+    axes.grid(True, alpha=0.3)
+    fig.tight_layout()
+
+    if filename is not None:
+        plt.savefig(filename)
+    if show:
+        plt.show()
+    elif hold is False:
+        plt.close(fig)

--- a/tests/on_one_core/test_plots.py
+++ b/tests/on_one_core/test_plots.py
@@ -2,6 +2,7 @@ import spyro
 from spyro import create_transect
 import pytest
 import os
+import numpy as np
 
 
 def is_seismicmesh_installed():
@@ -110,6 +111,22 @@ def test_plot_model_in_p1():
     filename = "model_p1.png"
     spyro.plots.plot_model_in_p1(wave_obj, filename=str(filename), show=False)
     assert os.path.exists(str(filename))
+
+
+def test_plot_receiver_response(tmp_path):
+    receiver_data = np.sin(np.linspace(0.0, 2.0 * np.pi, 100))
+    output_file = tmp_path / "receiver_response.png"
+
+    spyro.plots.plot_receiver_response(
+        receiver_data,
+        final_time=2.0,
+        show=False,
+        filename=str(output_file),
+        receiver_id_for_title=7,
+        name="trace",
+    )
+
+    assert output_file.exists()
 
 
 if __name__ == "__main__":

--- a/tests/on_one_core/test_time_io.py
+++ b/tests/on_one_core/test_time_io.py
@@ -1,0 +1,65 @@
+"""Test time series interpolation utilities (NumPy docstring style).
+
+This module contains tests for the `interpolate_time_series` function
+from `spyro.io.time_io`. The tests verify interpolation behaviour when
+the target time step is twice the source time step (half the temporal
+resolution).
+"""
+
+import numpy as np
+from spyro.io.time_io import interpolate_time_series
+
+
+def test_interpolate_time_series_three_receivers_half_dt():
+    """Interpolate a 3-receiver time series to a coarser temporal grid.
+
+    Verifies that linearly-varying signals for three receivers are correctly
+    interpolated when the `target_dt` is twice the `source_dt`. Uses a simple
+    analytic expression so expected values are known exactly.
+
+    Notes
+    -----
+    The source time vector is generated with `np.linspace` between
+    `initial_time` and `final_time` with spacing `source_dt`. The
+    interpolation should produce values matching the analytic expressions
+    evaluated on the coarser time grid.
+    """
+    initial_time = 0.0
+    final_time = 4.0
+    source_dt = 0.5
+    num_dt = int(np.round((final_time-initial_time) / source_dt) + 1)
+    target_dt = source_dt * 2.0
+
+    time_vector = np.linspace(initial_time, final_time, num_dt)
+
+    values = np.column_stack(
+        [
+            2.0 * time_vector + 1.0,
+            -time_vector + 3.0,
+            0.5 * time_vector - 2.0,
+        ]
+    )
+
+    interpolated = interpolate_time_series(
+        values,
+        target_dt=target_dt,
+        initial_time=initial_time,
+        final_time=final_time,
+    )
+
+    target_num_dt = int(np.round((final_time-initial_time) / target_dt) + 1)
+    target_time_vector = np.linspace(initial_time, final_time, target_num_dt)
+    expected = np.column_stack(
+        [
+            2.0 * target_time_vector + 1.0,
+            -target_time_vector + 3.0,
+            0.5 * target_time_vector - 2.0,
+        ]
+    )
+
+    assert interpolated.shape == expected.shape
+    assert np.allclose(interpolated, expected)
+
+
+if __name__ == "__main__":
+    test_interpolate_time_series_three_receivers_half_dt()


### PR DESCRIPTION
This pull request adds new functionality for time series interpolation and receiver response plotting, along with corresponding tests.

**New functionality:**

* Added `interpolate_time_series` to `spyro/io/time_io.py`, allowing resampling of time series data onto a new time grid with input validation and support for both 1D and 2D arrays. Now we can load or use real shot records that where generated on a dt different than on our simulation. This doesn't specify that it is for shot records, since its generic. However, it works and was made for use with shot records that aren't using the same dt as our simulation.

* Introduced `plot_receiver_response` in `spyro/plots/plots.py` to plot time-series data for a single receiver, with options for saving, labeling, and customizing the plot.

This is just an initial PR that is part of a bigger multiscale focused FWI feature set. I'm trying to go with small easily mergable PRs now. The next PR will have this used in FWI and present a tutorial