### PR TITLE
Add basic models

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:system"
+}

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     url="https://github.com/NDF-Poli-USP/spyro",
     packages=find_packages(),
     install_requires=[
+        "dataclasses",
         "numpy",
         "scipy",
         "matplotlib",

--- a/spyro/model/acquisition.py
+++ b/spyro/model/acquisition.py
@@ -1,0 +1,118 @@
+from dataclasses import InitVar, dataclass
+
+from attr import field
+import numpy as np
+import warnings
+import firedrake as fire
+from spyro.model.position import Position
+from spyro.model.time_axis import TimeAxis
+
+@dataclass
+class Receiver:
+    p: Position
+    real: np.array
+    synthetic: np.array = field(init=False)
+
+    def __post_init__(self):
+        self.synthetic =  np.zeros_like(self.real)
+
+    def sample(self, wave: fire.Function, time: TimeAxis):
+        self.synthetic[time.index] = wave.at(**self.p.get_positions())
+
+    def get_misfit(self):
+        residual = self.synthetic - self.data
+
+        return 0.5 * np.sum(residual**2)
+
+@dataclass
+class Source:
+    p: Position
+    space: InitVar[fire.FunctionSpace]
+    f: fire.Cofunction = field(init=False)
+
+    def __post_init__(self, space: fire.FunctionSpace):
+        self.f = fire.Cofunction(space.dual())
+
+        mesh = space.mesh()
+
+        source_mesh = fire.VertexOnlyMesh(
+            mesh,
+            [(self.x, self.y)]
+        )
+
+        source_space = fire.FunctionSpace(
+            source_mesh,
+            "DG",
+            0
+        )
+
+        self.source_value = fire.Function(source_space)
+        self.source_value.assign(1.0)
+
+    def update(self, time: TimeAxis):
+        amp = self.amplitude(time)
+        self.f.assign(amp*self.source_value)
+
+    def amplitude(self, time: TimeAxis):
+        return 0
+
+@dataclass
+class DataSource:
+    data: np.array
+
+    def amplitude(self, time: TimeAxis) -> float:
+        return self.data[time.index]
+
+@dataclass
+class RickerSource(Source):
+    delay: float
+    frequency: float
+
+    def amplitude(self, time: TimeAxis) -> float:
+        tau = time - self.delay
+
+        a = np.pi * self.frequency * tau
+
+        return (1.0 - 2.0 * a**2) * np.exp(-a**2)
+
+@dataclass
+class Acquisition:
+    sources: list[Source]
+    receivers: list[Receiver]
+
+    def __post_init__(self):
+        self.number_of_sources = len(self.source_locations)
+        self.number_of_receivers = len(self.receiver_locations)
+
+        if self.source_frequency < 1.0:
+            warnings.warn(
+                f"Frequency of {self.source_frequency} too low for realistic FWI."
+            )
+        elif self.source_frequency > 50:
+            warnings.warn(
+                f"Frequency of {self.source_frequency} too high for efficient FWI."
+            )
+
+    def get_source_function(self):
+        total = fire.Cofunction(self.sources[0].f.function_space())
+
+        total.assign(0)
+
+        for source in self.sources:
+            total += source.f
+
+        return total
+
+    def get_receivers_misfit(self):
+        return sum(
+            receiver.get_misfit()
+            for receiver in self.receivers
+        )
+
+    def update_sources(self, time: TimeAxis):
+        for source in self.sources:
+            source.update(time)
+
+    def sample_at_receivers(self, wave: fire.Function, time: TimeAxis):
+        for receiver in self.receivers:
+            receiver.sample(wave, time)

--- a/spyro/model/boundary.py
+++ b/spyro/model/boundary.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ReferenceFrequency(Enum):
+    BOUNDARY = "boundary"
+    SOURCE = "source"
+
+
+class ExtensionMode(Enum):
+    DRIVEN = "abc_driven"
+    BUILTIN = "builtin"
+
+
+@dataclass
+class BoundaryShape:
+    pass
+
+
+@dataclass
+class RectangularBoundary(BoundaryShape):
+    pass
+
+
+@dataclass
+class HypershapeBoundary(BoundaryShape):
+    degree: int
+    degree_type: str
+
+
+@dataclass
+class Boundary:
+    ref_model: bool
+    reference_freq: ReferenceFrequency
+    extension_mode: ExtensionMode
+    pad_length: float
+    shape: BoundaryShape
+    degree_eikonal: int = 2
+
+    def __post_init__(self):
+        if self.pad_length < 0:
+            raise ValueError("Pad length must be positive")
+
+
+@dataclass
+class PMLBoundary(Boundary):
+    shape: RectangularBoundary
+    max_acoustic_velocity: float
+    exponent: float = 2
+    R: float = 1e-6

--- a/spyro/model/mesh.py
+++ b/spyro/model/mesh.py
@@ -1,0 +1,125 @@
+from dataclasses import dataclass, field
+from abc import ABC, abstractmethod
+from enum import Enum
+import firedrake as fire
+from .. import meshing
+
+
+class MeshType(Enum):
+    FIREDRAKE_MESH = "firedrake_mesh"
+    USER_MESH = "user_mesh"
+    SEISMIC_MESH = "SeismicMesh"
+    FILE = "file"
+    SPYRO_MESH = "spyro_mesh"
+    GMSH_MESH = "gmsh_mesh"
+
+
+class FiniteElementMethod(Enum):
+    MASS_LUMPED_TRIANGLE = "mass_lumped_triangle"
+    DG_TRIANGLE = "DG_triangle"
+    SPECTRAL_QUADRILATERAL = "spectral_quadrilateral"
+    DG_QUATRILATERAL = "DG_quadrilateral"
+    CG_TRIANGLE = "CG_triangle"
+
+
+class CellType(Enum):
+    QUADRILATERAL = "quadrilateral"
+    TRIANGLE = "triangle"
+
+
+class Mesh(ABC):
+    @abstractmethod
+    def get_mesh(self, mesh_definition):
+        pass
+
+
+@dataclass
+class MeshDefinition:
+    mesh: Mesh
+    domain_dimensions: list[float]
+    negative_z: bool
+    mesh_type: MeshType
+    finite_element_method: FiniteElementMethod
+    abc_pad_length: float
+    cell_type: CellType
+    degree: int
+
+    dimension: int = field(init=False)
+
+    def __post_init__(self):
+        self.dimension = len(self.domain_dimensions)
+        if not all(x > 0 for x in self.domain_dimensions):
+            raise ValueError("All dimension lengths should be positive")
+
+        if self.negative_z:
+            self.domain_dimensions[0] = -self.domain_dimensions[0]
+
+    def assert_point_in_domain(self, point_coordinates):
+        """
+        Checks if a point is within the mesh domain.
+
+        Parameters
+        ----------
+        point_coordinates : list
+            Coordinates of the point to check.
+
+        Raises
+        ------
+        ValueError
+            If the point is outside the mesh domain.
+        """
+        for i, (coord, length) in enumerate(
+            zip(point_coordinates, self.domain_dimensions)
+        ):
+            error_message = (
+                f"Coordinate {coord} in dimension {i} is outside the domain "
+            )
+            self._assert_in_range(coord, length, error_message)
+
+    def _assert_in_range(self, coord, length, error_message):
+        low = min(0, length)
+        high = max(0, length)
+        if not low <= coord <= high:
+            raise ValueError(error_message + f"[{length}, 0].")
+
+    def get_mesh(self):
+        return self.mesh.get_mesh(self)
+
+
+@dataclass
+class ExistingMesh(Mesh):
+    mesh: object
+
+    def get_mesh(self, _):
+        return self.mesh
+
+
+@dataclass
+class MeshFile(Mesh):
+    file_name: str
+
+    def get_mesh(self, mesh_definition: MeshDefinition):
+        method = mesh_definition.method
+
+        return fire.Mesh(
+            mesh_definition.mesh_file,
+            comm=mesh_definition.comm,
+            distribution_parameters={
+                "overlap_type": (fire.DistributedMeshOverlapType.NONE, 0)
+            }
+            if method
+            in [
+                FiniteElementMethod.CG_TRIANGLE,
+                FiniteElementMethod.MASS_LUMPED_TRIANGLE,
+            ]
+            else None,
+        )
+
+
+class AutomatedMesh(Mesh):
+    edges_length: list[float]
+    cells_per_wavelength: object  # check type, mutually exclusive with edge length?, need frequency if set
+
+    def get_mesh(self, mesh_definition):
+        autoMeshing = meshing.AutomaticMesh(mesh_parameters=mesh_definition)
+        return autoMeshing.create_mesh()

--- a/spyro/model/models.py
+++ b/spyro/model/models.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from .parallelism import ParallelismConfig
+from .solver_input import SolverInput
+
+
+@dataclass
+class UpdateFrequency:
+    output_frequency: float = 99999
+    gradient_sampling_frequency: float
+
+
+@dataclass
+class OutputSpecification:
+    forward_output: str | None = None
+    velocity_model_filename: str | None = None
+    gradient_filename: str | None = None
+
+
+@dataclass
+class ExecutionConfig:
+    solver_input: SolverInput
+    update_frequency: UpdateFrequency
+    output: OutputSpecification
+    parallelism_config: ParallelismConfig
+
+    def __post_init__(self):
+        self.mesh.assert_point_in_domain(self.acquisition.source_frequency)
+        self.mesh.assert_point_in_domain(self.acquisition.receiver_locations)
+        self.parallelismConfig.setup(self.acquisition.source_locations)
+
+    def get_mesh(self):
+        return self.mesh.get_mesh()

--- a/spyro/model/operator/acoustic_operator_builder.py
+++ b/spyro/model/operator/acoustic_operator_builder.py
@@ -1,0 +1,71 @@
+
+import firedrake as fire
+from firedrake import ds, dx, Constant, dot, grad
+from spyro.model.boundary import Boundary
+from spyro.model.solver_input import SolverInput
+
+class AcousticSolverOperatorBuilder(SolverOperatorBuilder):
+    def build(wave: Wave, solver_input: SolverInput):
+        V = wave.function_space
+        quad_rule = wave.quadrature_rule
+
+        u = fire.TrialFunction(V)
+        v = fire.TestFunction(V)
+        
+        u_nm1 = fire.Function(V, name="pressure t-dt")
+        u_n = fire.Function(V, name="pressure")
+        u_np1 = fire.Function(V, name="pressure t+dt")
+
+        dt = solver_input.time_axis.dt
+
+        m1 = (
+            (1 / (wave.c * wave.c))
+            * ((u - 2.0 * u_n + u_nm1) / Constant(dt**2))
+            * v
+            * dx(**quad_rule)
+        )
+
+        a = dot(grad(u_n), grad(v)) * dx(**quad_rule)
+
+        le = 0.0
+
+        if solver_input.boundary:
+            weak_expr_abc = dot((u_n - u_nm1) / Constant(dt), v)
+
+            f_abc = (1 / wave.c) * weak_expr_abc
+            qr_s = wave.surface_quadrature_rule
+
+            if wave.abc_boundary_layer_type == "hybrid":
+
+                # NRBC
+                le += Wave_object.cosHig * f_abc * ds(**qr_s)
+
+                # Damping
+                le += Wave_object.eta_mask * weak_expr_abc * \
+                    (1 / (Wave_object.c * Wave_object.c)) * \
+                    Wave_object.eta_habc * dx(**quad_rule)
+
+            else:
+                if Wave_object.absorb_top:
+                    le += f_abc*ds(1, **qr_s)
+                if Wave_object.absorb_bottom:
+                    le += f_abc*ds(2, **qr_s)
+                if Wave_object.absorb_right:
+                    le += f_abc*ds(3, **qr_s)
+                if Wave_object.absorb_left:
+                    le += f_abc*ds(4, **qr_s)
+                if Wave_object.dimension == 3:
+                    if Wave_object.absorb_front:
+                        le += f_abc*ds(5, **qr_s)
+                    if Wave_object.absorb_back:
+                        le += f_abc*ds(6, **qr_s)
+        form = m1 + a + le
+
+        lin_var = fire.LinearVariationalProblem(
+            fire.rhs(form),
+            fire.lhs(form) + fire.Cofunction(V.dual()),
+            u_np1, constant_jacobian=True)
+        
+        return fire.LinearVariationalSolver(
+            lin_var, solver_parameters= solver_input.solver_parameters | {"mat_type": "matfree"},
+        )

--- a/spyro/model/parallelism.py
+++ b/spyro/model/parallelism.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, field
+from enum import Enum
+from .. import utils
+
+
+class ParallelismType(Enum):
+    CUSTOM = "custom"
+    AUTOMATIC = "automatic"
+    SPATIAL = "spatial"
+
+
+@dataclass
+class ParallelismConfig:
+    type: ParallelismType
+    shot_ids_per_propagation: list | None = None
+    comm: object = field(init=False)  # dont know the object type yet
+
+    def __post_init__(self):
+        if type == ParallelismType.CUSTOM and self.shot_ids_per_propagation is None:
+            raise ValueError(
+                "shot_ids_per_propagation not specified "
+                + "for ParallelismConfig even though type is CUSTOM"
+            )
+
+    def setup(self, number_of_sources):
+        self.comm = utils.mpi_init(self)
+        self.comm.comm.barrier()
+        if type != ParallelismType.CUSTOM:
+            self.shot_ids_per_propagation = [[i] for i in range(0, number_of_sources)]

--- a/spyro/model/solver_input.py
+++ b/spyro/model/solver_input.py
@@ -1,0 +1,83 @@
+from dataclasses import dataclass, field
+from enum import Enum
+import numpy as np
+import warnings
+from .mesh import Mesh
+from .boundary import Boundary
+
+
+class SourceTypes(Enum):
+    RICKER = "ricker"
+    MMS = "MMS"
+
+
+class DelayType(Enum):
+    MULTIPLE_OF_MINIMUM = "multiples_of_minimum"
+    TIME = "time"
+
+
+class EquationType(Enum):
+    SECOND_ORDER_IN_PRESSURE = "second_order_in_pressure"
+
+
+class Variant(Enum):
+    LUMPED = "lumped"
+    EQUISPACED = "equispaced"
+    DG = "DG"
+
+
+@dataclass
+class Acquisition:
+    receiver_locations: np.array
+    delay: float
+    delay_type: DelayType
+    source_type: SourceTypes
+    source_frequency: float
+    source_locations: np.array | None = None  # can this be null?
+
+    number_of_sources: int = field(init=False)
+
+    def __post_init__(self):
+        self.number_of_sources = len(self.source_locations)
+        self.number_of_receivers = len(self.receiver_locations)
+
+        if self.source_frequency < 1.0:
+            warnings.warn(
+                f"Frequency of {self.source_frequency} too low for realistic FWI."
+            )
+        elif self.source_frequency > 50:
+            warnings.warn(
+                f"Frequency of {self.source_frequency} too high for efficient FWI."
+            )
+
+        if self.source_type != SourceTypes.MMS and self.source_locations is None:
+            raise ValueError("source_locations should not be None if source_type is not MMS")
+
+
+@dataclass
+class TimeAxis:
+    initial_time: float
+    final_time: float
+    dt: float | None
+    amplitude: float
+
+    def __post_init__(self):
+        if self.final_time < 0.0:
+            raise ValueError(f"Negative time of {self.final_time} not valid.")
+        if self.dt > 1.0:
+            warnings.warn(f"Time step of {self.dt} too big.")
+        if self.dt is None:
+            warnings.warn(
+                "Timestep not given. Will calculate internally when user \
+                    attemps to propagate wave."
+            )
+
+
+@dataclass
+class SolverInput:
+    equation_type: EquationType
+    mesh: Mesh
+    boundary: Boundary
+    acquisition: Acquisition
+    time_axis: TimeAxis
+    variant: Variant

--- a/spyro/model/time_axis.py
+++ b/spyro/model/time_axis.py
@@ -1,0 +1,29 @@
+from dataclasses import field, dataclass
+import warnings
+
+@dataclass
+class TimeAxis:
+    initial_time: float
+    final_time: float
+    dt: float | None
+    amplitude: float
+    current_time: float = field(init=False)
+    index: int = field(init=False)
+
+    def __post_init__(self):
+        if self.final_time < 0.0:
+            raise ValueError(f"Negative time of {self.final_time} not valid.")
+        if self.dt > 1.0:
+            warnings.warn(f"Time step of {self.dt} too big.")
+        if self.dt is None:
+            warnings.warn(
+                "Timestep not given. Will calculate internally when user \
+                    attemps to propagate wave."
+            )
+
+        self.current_time = self.initial_time
+        self.index = 0
+
+    def update(self):
+        self.current_time += self.dt
+        self.index += 1

--- a/spyro/model/tmp_solver/solver.py
+++ b/spyro/model/tmp_solver/solver.py
@@ -1,0 +1,41 @@
+from abc import ABC
+from dataclasses import dataclass, field
+
+from ..models import ExecutionConfig
+from ..wave import Wave
+
+class ForwardWavePropagatorStrategy:
+    def propagate(wave: Wave):
+        pass
+
+class BackwardWavePropagatorStrategy:
+    def propagate(wave: Wave):
+        pass
+
+class SolverOperatorBuilder:
+    def build(wave: Wave):
+        pass
+
+
+class PMLSolverOperatorBuilder:
+    def build(wave: Wave):
+        pass
+
+
+@dataclass
+class Solver(ABC):
+    input: ExecutionConfig
+    forward_wave_propagator: ForwardWavePropagatorStrategy # default can be _forward_time_integrator
+    backwards_wave_propagator: BackwardWavePropagatorStrategy
+    solver_operator_builder: SolverOperatorBuilder
+    wave: Wave = field(init=False)
+
+    def forward_solve(self, initial_velocity_file):
+        mesh_definition = self.input.solver_input.mesh_definition
+        wave = Wave(mesh_definition, initial_velocity_file)
+        matrix = self.solver_operator_builder.build(self.wave, self.input.solver_input)
+        return self.forward_wave_propagator.propagate(matrix, wave)
+
+    def gradient_solve():
+        pass
+

--- a/spyro/model/wave.py
+++ b/spyro/model/wave.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass, field
+from typing import Any
+from firedrake import (
+    FiniteElement, FunctionSpace, VectorElement, Function
+)
+from spyro.model.mesh import FiniteElementMethod, MeshDefinition
+from ufl.finiteelement import AbstractFiniteElement
+
+_ELEMENT_SPECS = {
+    "mass_lumped_triangle": ("KMV", None, None),
+    "KMV": ("KMV", None, None),
+    "Kong-Mulder-Veldhuizen": ("KMV", None, None),
+    "spectral_quadrilateral": ("CG", "spectral", None),
+    "DG0": ("DG", None, 0),
+    "DG_triangle": ("DG", None, None),
+    "DG_quadrilateral": ("DG", None, None),
+    "DG": ("DG", None, None),
+    "CG_triangle": ("CG", None, None),
+    "CG_quadrilateral": ("CG", None, None),
+    "CG": ("CG", None, None),
+    "DQ_quadrilateral": ("DQ", "spectral", None),
+    "DQ": ("DQ", "spectral", None),
+}
+
+@dataclass
+class Wave:
+    function_space: FunctionSpace = field(init=False)
+    scalar_function_space: FunctionSpace = field(init=False)
+    velocity_model: Function = field(init=False) # remeber to set this later
+    quadrature_rule: Any
+    c: Any
+    current_time: float = field(default=0, init=False)
+
+    def __post_init__(self, mesh: MeshDefinition, initial_velocity_file: str):
+        self._validate_args(mesh.finite_element_method, mesh.degree, mesh.dimension)
+        self.function_space = self._get_function_space(mesh.get_mesh(), mesh.method, mesh.degree, mesh.dimension)
+        
+    def _validate_args(method: FiniteElementMethod, degree: int, dimension: int):
+        if dimension is None or dimension < 1:
+            raise ValueError(f"Dimension must be greater than 1, but found {dimension}")
+        
+        if degree is None or degree < 0:
+            raise ValueError(f"Degree must be a positive integer, but found {dimension}")
+
+        if method not in _ELEMENT_SPECS:
+            raise ValueError(f"Finite element method {method} not supported")
+
+    @classmethod
+    def from_finite_element(self, mesh_definition: MeshDefinition, initial_velocity_file: str, element: AbstractFiniteElement):
+        self.function_space = FunctionSpace(mesh_definition.get_mesh(), element)
+
+    def _get_function_space(self, mesh: object, method: FiniteElementMethod, degree: int, dimension: int = 1):
+        family, variant, fixed_degree = _ELEMENT_SPECS[method]
+
+        degree = degree if fixed_degree is not None else fixed_degree
+
+        element = FiniteElement(family, mesh.ufl_cell(), degree=degree, variant=variant)
+
+        if dimension > 1:
+            return FunctionSpace(mesh, VectorElement(element, dim=dimension))
+
+        return FunctionSpace(mesh, element)


### PR DESCRIPTION
This PR adds models that we can use to do input validation and better organize code. This is currently just a proposal and i need feedback to understand how can we better organize the data structures. For now i created the following data models (please, correct me if they dont make sense to you):

- ExecutionConfig: this model should contain all information required to run a solver. It contains the solver input, parallelism information and the output specification. The main goal of this data model is to decouple computational information (how much cores will be used? which folder will be used to save output?) from the problem specification that will be isolated in the solver_input field.

- ParallelismConfig: This data model will contain any information regarding parallelism. For now it contains only the ParallelismType, shot_ids_per_propagation and the comm.

- OutputSpecification: This data model will contain all information regarding where the output will be saved.

- SolverInput: this model contains the problem specification. It contains the Mesh, Time information, boundaries, equationType, acquisition information and variant (i dont know exactly what the variant is but i left it here for now)

- MeshDefinition: this data model will be equivalent to meshing_parameters. It should contain all information regarding a mesh.

- Mesh: this is the actual mesh object. I saw that there can be some types of these objects so i created a abstract class that we can extend to create new mesh types. I dont know if this is a good approach but i think it can be cleaner than the current approach in meshing_paramters.

- Boundary: This data model will be equivalent to the Read_boundary_layer type. I dont know if it makes more sense for it to be in the mesh or in the SolverInput. It is possible that some fields are missing here and i will probably need the help of you guys.

