### PR TITLE
Fix circular import between spyro.abc and spyro.habc

### DIFF
--- a/spyro/abc/__init__.py
+++ b/spyro/abc/__init__.py
@@ -1,9 +1,8 @@
-import importlib
-import pkgutil
+# Submodules of this package are imported explicitly by their users, e.g.
+#     from ..abc.abc_layer import ABCLayer
+#
+# Do not eagerly import every submodule here (e.g. with pkgutil/importlib):
+# it makes touching any single abc submodule import the whole package, which
+# is the other half of the spyro.abc <-> spyro.habc circular import.
 
 __all__ = []
-for module_info in pkgutil.walk_packages(__path__):
-    module_name = module_info.name
-    __all__.append(module_name)
-    module = importlib.import_module(f"{__name__}.{module_name}")
-    globals()[module_name] = module

--- a/spyro/habc/__init__.py
+++ b/spyro/habc/__init__.py
@@ -1,9 +1,10 @@
-import importlib
-import pkgutil
+# Submodules of this package are imported explicitly by their users, e.g.
+#     from ..habc.error_measure import HABCError
+#
+# Do not eagerly import every submodule here (e.g. with pkgutil/importlib).
+# Doing so turns the one-way dependency
+#     abc.abc_layer -> habc.error_measure
+# into a circular import, because pulling in any single habc submodule would
+# also pull in habc.habc, which subclasses abc.abc_layer.ABCLayer.
 
 __all__ = []
-for module_info in pkgutil.walk_packages(__path__):
-    module_name = module_info.name
-    __all__.append(module_name)
-    module = importlib.import_module(f"{__name__}.{module_name}")
-    globals()[module_name] = module


### PR DESCRIPTION
# Fix circular import between `spyro.abc` and `spyro.habc`

## The symptom

On a clean checkout of `main`, this fails:

```console
$ python -c "from spyro.pml.pml_nsnc import PMLLayer"
ImportError: cannot import name 'ABCLayer' from partially initialized
module 'spyro.abc.abc_layer' (most likely due to a circular import)
```

It also makes `tests/on_one_core/test_gradient_2d_pml.py::test_gradient_auto_adjoint` fail.

Note that `import spyro` works fine, which is why this went unnoticed. The reason is
not a lucky import order: `import spyro` simply never reaches these packages at all.
The imports of `abc`/`habc` live inside the `Wave.layer_manager` property
(`spyro/solvers/wave.py:705` and `:714`), so they only fire at *runtime*, when an
absorbing layer is actually configured. A PML run enters through
`spyro.pml.pml_nsnc`, and that is the entry point that breaks.


## What actually creates the cycle

Both `spyro/abc/__init__.py` and `spyro/habc/__init__.py` walked their own package
and eagerly imported every submodule:

```python
for module_info in pkgutil.walk_packages(__path__):
    module = importlib.import_module(f"{__name__}.{module_name}")
```

Python always executes a package's `__init__.py` before any of its submodules, so
this means: **asking for one module of the package imports all of them.**

That is what turns the one-way edge into a cycle. Asking for the harmless leaf
`habc.error_measure` also drags in `habc.habc`, which points back at
`abc.abc_layer`:

```
from spyro.pml.pml_nsnc import PMLLayer
└─ pml_nsnc.py:3      from ..abc.abc_layer import ABCLayer
   └─ runs spyro/abc/__init__.py
      └─ sweep, first module: abc_layer
         └─ abc_layer.py:8   from ..habc.error_measure import HABCError
            └─ runs spyro/habc/__init__.py
               └─ sweep reaches habc.py
                  └─ habc.py:5   from ..abc.abc_layer import ABCLayer
                     └─ abc_layer is in sys.modules but still executing line 8;
                        class ABCLayer (line 32) does not exist yet  --> ImportError
```

## It only worked by accident of filename ordering

Worth highlighting, because it shows how fragile the previous state was. On `main`,
entering through `habc` works but entering through `abc` does not:

| statement (on current `main`) | result |
|---|---|
| `import spyro.habc.habc` | works |
| `import spyro.habc.error_measure` | works |
| `import spyro.abc.abc_layer` | **ImportError** |
| `import spyro.abc.nrbc` | **ImportError** |

`pkgutil.walk_packages` yields modules in alphabetical order:

```
spyro/habc -> ['damp_profile', 'error_measure', 'habc']
spyro/abc  -> ['abc_layer', 'eik_min', 'hyp_lay', 'lay_len', 'nrbc', 'rec_lay']
```

Entering through `habc`, the sweep loads `error_measure` *before* `habc` (E < H), so
by the time `habc.py` triggers the round trip, `habc.error_measure` is already
complete in `sys.modules` and the cycle closes harmlessly. Entering through `abc`,
`abc_layer` is the *first* module (A), so it fires the chain before anything is
ready.

In other words, the package only imported correctly because of how the files happen
to be named. Renaming `error_measure.py` to anything sorting after `habc.py` would
have broken the other entry point too.

## The fix

Deferring the import in `habc.py` into a function is not possible: `ABCLayer` is a
**base class**, needed when the class is defined, not when a method runs.

So this PR removes the eager sweeps instead, which is the actual root cause. Nothing
depended on them — every consumer already imports the submodule it needs explicitly:

```python
from ..abc.abc_layer import ABCLayer      # spyro/pml/pml_nsnc.py, spyro/habc/habc.py
from ..habc.error_measure import HABCError # spyro/abc/abc_layer.py
import spyro.habc.habc as habc            # tests/on_one_core/test_f8.py
import spyro.abc.eik_min as eik_min       # tests/on_one_core/test_f8.py
```

Nothing accesses `spyro.abc.<module>` / `spyro.habc.<module>` as a package attribute,
which was the only thing the sweep provided. With the sweep gone,
`from ..habc.error_measure import HABCError` loads just the leaf module, `habc.py`
never enters the picture, and the straight-line graph above resolves naturally.

I removed the sweep from `spyro/abc/__init__.py` as well: it is the exact mirror image
of the same hazard, and leaving it would keep the package one refactor away from the
same class of bug.

## Verification

All entry points into the two packages, before and after:

| statement | before | after |
|---|---|---|
| `from spyro.pml.pml_nsnc import PMLLayer` | ImportError | OK |
| `from spyro.abc.abc_layer import ABCLayer` | ImportError | OK |
| `import spyro.abc.nrbc` | ImportError | OK |
| `from spyro.habc.habc import HABCLayer` | OK | OK |
| `from spyro.habc.error_measure import HABCError` | OK | OK |
| `import spyro` | OK | OK |

- `pytest tests/on_one_core/test_gradient_2d_pml.py -q` -> **3 passed, 1 skipped**
- `pytest tests/ --collect-only` -> **460 tests collected**, i.e. every test module imports
- `flake8` clean on both changed files

Two pre-existing failures are unrelated to this change; I confirmed both are identical
with the original `__init__.py` files restored:

- `tests/on_one_core/test_elastic_local_abc.py` errors at collection time — it reads
  `/proc/meminfo`, which does not exist on macOS.
- `tests/on_one_core/test_habc_tools.py` has 1 failing assertion (line 249), on `main`
  as well as on this branch.