### PR TITLE
docs: update README mesh setup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ dictionary["visualization"] = {
 wave = spyro.AcousticWave(dictionary=dictionary)
 
 # Defines the element size in the automatically generated firedrake mesh.
-wave.set_mesh(dx=0.01)
+wave.set_mesh(input_mesh_parameters={"edge_length": 0.01})
 
 
 # Manually create a simple two layer seismic velocity model.


### PR DESCRIPTION
## Summary

- update the README's automatic-mesh example to use the current `set_mesh` API
- pass `edge_length` through `input_mesh_parameters` instead of the removed `dx` keyword

## Validation

- `git diff --check`
- verified the documented keyword and nested `edge_length` parameter against the current `Wave.set_mesh` and `MeshingParameters` implementations
- Firedrake demo not run locally because the Firedrake runtime is unavailable on macOS

Closes #291
