### PR TITLE
Removing tests from drafts

### DIFF
--- a/.github/workflows/build_firedrake_main.yml
+++ b/.github/workflows/build_firedrake_main.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     - cron: '0 0 * * 0'
-# on: [push, pull_request]
 
 concurrency:
   group: build-firedrake-main-${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   test:
     name: build
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: self-hosted
 
     container:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,8 +7,9 @@ on:
   push:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  permissions:
-    contents: read
+
+permissions:
+  contents: read
 
 concurrency:
   # Cancel running jobs if new commits are pushed

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,10 +3,12 @@
 
 name: Python tests
 
-on: [push, pull_request]
-
-permissions:
-  contents: read
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  permissions:
+    contents: read
 
 concurrency:
   # Cancel running jobs if new commits are pushed
@@ -80,8 +82,8 @@ jobs:
     name: Slow Tests and Parallel Tests
     runs-on: self-hosted
     needs: fast-tests
-    if: github.event_name == 'pull_request'
-    # Only runs on PRs after fast tests pass - saves resources
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    # Only runs on non-draft PRs after fast tests pass - saves resources
 
     container:
       image: firedrakeproject/firedrake:2025.4.1
@@ -197,8 +199,8 @@ jobs:
     name: Updated Firedrake tests
     runs-on: self-hosted
     needs: slow-tests
-    if: github.event_name == 'pull_request'
-    # Only runs on PRs after fast tests pass - saves resources
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    # Only runs on non-draft PRs after slow tests pass - saves resources
 
     container:
       image: firedrakeproject/firedrake:2026.4.0


### PR DESCRIPTION
Draft PRs are generally still under development and do not need the full test suite to run on every update. This is a regular PR. I am opening it as a draft to check how tests will run