### PR TITLE
Automated adjoint for the isotropic elastic wave

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -260,6 +260,7 @@ jobs:
           mpiexec -n 3 pytest tests/parallel/test_supershot_grad.py
           mpiexec -n 2 pytest tests/parallel/test_gradient_serialshots.py
           mpiexec -n 2 pytest tests/parallel/test_gradient_auto_adjoint.py
+          mpiexec -n 2 pytest tests/parallel/test_elastic_sources_parallel.py
 
     - name: Post-run cleanup
       if: always()

--- a/spyro/solvers/acoustic_wave.py
+++ b/spyro/solvers/acoustic_wave.py
@@ -226,7 +226,11 @@ class AcousticWave(Wave):
                         AcousticMaterialParameter.P_WAVE_VELOCITY, self.c,
                     )
                     return
-                raise ValueError("No velocity model or velocity file to load.")
+                raise ValueError(
+                    "No velocity model or velocity file to load. Set one "
+                    "with set_initial_velocity_model(), or assign the "
+                    "velocity field to self.c directly."
+                )
 
             if self.initial_velocity_model_file.endswith(".segy"):
                 self.initial_velocity_model_file = write_hdf5_velocity_model(self, self.initial_velocity_model_file)

--- a/spyro/solvers/acoustic_wave.py
+++ b/spyro/solvers/acoustic_wave.py
@@ -191,9 +191,9 @@ class AcousticWave(Wave):
             )
 
         if riesz_map == RieszMapType.L2:
-            return self.automated_adjoint.compute_gradient()
+            return self.automated_adjoint.compute_gradient()[0]
         elif riesz_map == RieszMapType.l2:
-            return self.automated_adjoint.compute_derivative()
+            return self.automated_adjoint.compute_derivative()[0]
         else:
             raise NotImplementedError(
                 f"Riesz map {riesz_map} not implemented for automated adjoint."

--- a/spyro/solvers/acoustic_wave.py
+++ b/spyro/solvers/acoustic_wave.py
@@ -191,9 +191,9 @@ class AcousticWave(Wave):
             )
 
         if riesz_map == RieszMapType.L2:
-            return self.automated_adjoint.compute_gradient()[0]
+            return self.automated_adjoint.compute_gradient()
         elif riesz_map == RieszMapType.l2:
-            return self.automated_adjoint.compute_derivative()[0]
+            return self.automated_adjoint.compute_derivative()
         else:
             raise NotImplementedError(
                 f"Riesz map {riesz_map} not implemented for automated adjoint."

--- a/spyro/solvers/automatic_differentiation_solver.py
+++ b/spyro/solvers/automatic_differentiation_solver.py
@@ -14,9 +14,9 @@ def _as_list(value: object) -> list:
 
     Parameters
     ----------
-    value : object, mapping, list, tuple, or None
-        Value to normalize. Mappings contribute their values and ``None``
-        produces an empty list.
+    value : object, mapping, PhysicalParameters, list, tuple, or None
+        Value to normalize. Anything keyed by name contributes its values,
+        and ``None`` produces an empty list.
 
     Returns
     -------
@@ -25,7 +25,7 @@ def _as_list(value: object) -> list:
     """
     if value is None:
         return []
-    if isinstance(value, Mapping) or hasattr(value, "items"):
+    if isinstance(value, (Mapping, PhysicalParameters)):
         return list(value.values())
     if isinstance(value, (list, tuple)):
         return list(value)
@@ -70,11 +70,18 @@ class AutomatedAdjoint:
     .. code-block:: python
 
         wave.enable_automated_adjoint(control_parameters=parameters)
-        with wave.automated_adjoint.fresh_tape():
-            wave.forward_solve()          # forward run recorded on the tape
+        wave.forward_solve()          # the time integrator starts recording
+        dJ = wave.gradient_solve()    # one derivative per selected parameter
+        wave.automated_adjoint.clear_tape()
+
+    ``gradient_solve`` builds the reduced functional from the recorded tape
+    on its first call. Building it here is only needed to hold on to it, or
+    to run a Taylor test against it:
+
+    .. code-block:: python
+
         wave.automated_adjoint.create_reduced_functional(wave.functional_value)
-        dJ = wave.automated_adjoint.compute_gradient()
-        rate = wave.automated_adjoint.verify_gradient(wave.c)  # Taylor test
+        rate = wave.automated_adjoint.verify_gradient(wave.c)
 
     Parameters
     ----------
@@ -106,33 +113,17 @@ pyadjoint.ReducedFunctional or None
     """
 
     def __init__(self, ensemble: object, controls: object = None) -> None:
-        self.controls = []
-        self.control_parameter_names = []
         self.ensemble = ensemble
         self.reduced_functional = None
         self._tape = None
-        self._set_controls(controls)
-
-    def _set_controls(self, controls: object) -> None:
-        """Store labeled or unlabeled control fields as ordered lists.
-
-        Parameters
-        ----------
-        controls : object or iterable
-            Control fields, optionally exposed through an ``items`` method.
-
-        Returns
-        -------
-        None
-        """
-        try:
-            control_items = list(controls.items())
-        except AttributeError:
+        if isinstance(controls, (Mapping, PhysicalParameters)):
+            # Keyed by material parameter: keep the labels, so the
+            # derivatives can be handed back under the same names.
+            self.control_parameter_names = list(controls)
+            self.controls = list(controls.values())
+        else:
             self.controls = _as_list(controls)
             self.control_parameter_names = [None] * len(self.controls)
-        else:
-            self.control_parameter_names = [name for name, _ in control_items]
-            self.controls = [value for _, value in control_items]
 
     @contextmanager
     def fresh_tape(self):

--- a/spyro/solvers/automatic_differentiation_solver.py
+++ b/spyro/solvers/automatic_differentiation_solver.py
@@ -277,7 +277,11 @@ pyadjoint.ReducedFunctional or None
         """
         if not self.controls:
             raise ValueError("At least one control is required.")
-        control = [fire_ad.Control(value) for value in self.controls]
+        controls = [fire_ad.Control(value) for value in self.controls]
+        # pyadjoint mirrors the shape it is given: a bare control comes back
+        # as a bare derivative, a list as a list. Handing it a one-item list
+        # would make every single-control caller unwrap by hand.
+        control = controls[0] if len(controls) == 1 else controls
 
         self.reduced_functional = fire_ad.EnsembleReducedFunctional(
             functional,
@@ -311,7 +315,7 @@ pyadjoint.ReducedFunctional or None
             raise ValueError("Reduced functional not created.")
         return self.reduced_functional(_as_list(control_value))
 
-    def compute_gradient(self) -> list:
+    def compute_gradient(self) -> object:
         """Return the gradient of the functional.
 
         Computes the gradient via reverse-mode differentiation of the tape and maps
@@ -321,8 +325,9 @@ pyadjoint.ReducedFunctional or None
 
         Returns
         -------
-        list of firedrake.Function
-            One gradient for each control.
+        firedrake.Function or list of firedrake.Function
+            The gradient, or one for each control when there is more than
+            one.
 
         Raises
         ------
@@ -331,11 +336,9 @@ pyadjoint.ReducedFunctional or None
         """
         if self.reduced_functional is None:
             raise ValueError("Reduced functional not created.")
-        return _as_list(
-            self.reduced_functional.derivative(apply_riesz=True),
-        )
+        return self.reduced_functional.derivative(apply_riesz=True)
 
-    def compute_derivative(self) -> list:
+    def compute_derivative(self) -> object:
         """Return the raw derivative of the functional.
 
         Similar to :meth:`compute_gradient` but without the Riesz map
@@ -347,8 +350,9 @@ pyadjoint.ReducedFunctional or None
 
         Returns
         -------
-        list of firedrake.Cofunction
-            One derivative for each control.
+        firedrake.Cofunction or list of firedrake.Cofunction
+            The derivative, or one for each control when there is more than
+            one.
 
         Raises
         ------
@@ -357,9 +361,7 @@ pyadjoint.ReducedFunctional or None
         """
         if self.reduced_functional is None:
             raise ValueError("Reduced functional not created.")
-        return _as_list(
-            self.reduced_functional.derivative(apply_riesz=False),
-        )
+        return self.reduced_functional.derivative(apply_riesz=False)
 
     def label_derivatives(self, derivatives: object) -> PhysicalParameters:
         """Associate computed derivatives with selected physical parameters.

--- a/spyro/solvers/automatic_differentiation_solver.py
+++ b/spyro/solvers/automatic_differentiation_solver.py
@@ -1,9 +1,33 @@
 from contextlib import contextmanager
+from collections.abc import Mapping
 
 from pyadjoint import Tape, continue_annotation, pause_annotation, taylor_test
 
 import firedrake as fire
 import firedrake.adjoint as fire_ad
+
+
+def _as_list(value: object) -> list:
+    """Return one value or collection as a list.
+
+    Parameters
+    ----------
+    value : object, mapping, list, tuple, or None
+        Value to normalize. Mappings contribute their values and ``None``
+        produces an empty list.
+
+    Returns
+    -------
+    list
+        Normalized values.
+    """
+    if value is None:
+        return []
+    if isinstance(value, Mapping) or hasattr(value, "items"):
+        return list(value.values())
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
 
 
 class AutomatedAdjoint:
@@ -52,10 +76,10 @@ class AutomatedAdjoint:
 
     Parameters
     ----------
-    controls : firedrake.Function, optional
-        The control with respect to which the functional is differentiated.
-        It is wrapped in a :class:`pyadjoint.Control` when the reduced functional is
-        created.
+    controls : object or iterable, optional
+        Controls with respect to which the functional is differentiated. A
+        labeled container such as ``PhysicalParameters`` may also be supplied.
+        Internally controls are always represented as a list.
     ensemble : firedrake.ensemble.Ensemble, optional
         The Firedrake ensemble communicator used to sum the per-shot
         functionals and gradients across ensemble members. In practice this is
@@ -64,8 +88,11 @@ class AutomatedAdjoint:
 
     Attributes
     ----------
-    controls : firedrake.Function
-        The control passed at construction time.
+    controls : list
+        Controls passed at construction time.
+    control_parameter_names : list
+        Labels supplied by a control container, or ``None`` for unlabeled
+        controls.
     ensemble : firedrake.ensemble.Ensemble or None
         The ensemble communicator used by the reduced functional.
     reduced_functional : firedrake.adjoint.EnsembleReducedFunctional or \
@@ -74,8 +101,15 @@ pyadjoint.ReducedFunctional or None
         :meth:`create_reduced_functional`.
     """
 
-    def __init__(self, ensemble, controls=None):
-        self.controls = controls
+    def __init__(self, ensemble: object, controls: object = None) -> None:
+        try:
+            control_items = list(controls.items())
+        except AttributeError:
+            self.controls = _as_list(controls)
+            self.control_parameter_names = [None] * len(self.controls)
+        else:
+            self.control_parameter_names = [name for name, _ in control_items]
+            self.controls = [value for _, value in control_items]
         self.ensemble = ensemble
         self.reduced_functional = None
         self._tape = None
@@ -139,7 +173,9 @@ pyadjoint.ReducedFunctional or None
         fire_ad.set_working_tape(Tape())
         pause_annotation()
 
-    def create_reduced_functional(self, functional, ensemble=None):
+    def create_reduced_functional(
+        self, functional: object, ensemble: object = None,
+    ) -> object:
         """Build the reduced functional for the recorded forward problem.
 
         The reduced functional ties the (local) functional value to the control
@@ -165,7 +201,9 @@ pyadjoint.ReducedFunctional or None
             The reduced functional, also stored on
             :attr:`reduced_functional`.
         """
-        control = fire_ad.Control(self.controls)
+        if not self.controls:
+            raise ValueError("At least one control is required.")
+        control = [fire_ad.Control(value) for value in self.controls]
 
         self.reduced_functional = fire_ad.EnsembleReducedFunctional(
             functional,
@@ -176,13 +214,13 @@ pyadjoint.ReducedFunctional or None
         )
         return self.reduced_functional
 
-    def recompute_functional(self, control_value):
+    def recompute_functional(self, control_value: object) -> object:
         """Re-evaluate the reduced functional at a new control value.
 
         Parameters
         ----------
-        control_value : firedrake.Function
-            The control at which to evaluate the functional.
+        control_value : firedrake.Function or iterable of firedrake.Function
+            Controls at which to evaluate the functional.
 
         Returns
         -------
@@ -197,9 +235,9 @@ pyadjoint.ReducedFunctional or None
         """
         if self.reduced_functional is None:
             raise ValueError("Reduced functional not created.")
-        return self.reduced_functional(control_value)
+        return self.reduced_functional(_as_list(control_value))
 
-    def compute_gradient(self):
+    def compute_gradient(self) -> list:
         """Return the gradient of the functional.
 
         Computes the gradient via reverse-mode differentiation of the tape and maps
@@ -209,8 +247,8 @@ pyadjoint.ReducedFunctional or None
 
         Returns
         -------
-        firedrake.Function
-            The gradient of the functional with respect to the control.
+        list of firedrake.Function
+            One gradient for each control.
 
         Raises
         ------
@@ -219,9 +257,11 @@ pyadjoint.ReducedFunctional or None
         """
         if self.reduced_functional is None:
             raise ValueError("Reduced functional not created.")
-        return self.reduced_functional.derivative(apply_riesz=True)
+        return _as_list(
+            self.reduced_functional.derivative(apply_riesz=True),
+        )
 
-    def compute_derivative(self):
+    def compute_derivative(self) -> list:
         """Return the raw derivative of the functional.
 
         Similar to :meth:`compute_gradient` but without the Riesz map
@@ -233,8 +273,8 @@ pyadjoint.ReducedFunctional or None
 
         Returns
         -------
-        firedrake.Cofunction
-            The derivative of the functional with respect to the control.
+        list of firedrake.Cofunction
+            One derivative for each control.
 
         Raises
         ------
@@ -243,9 +283,14 @@ pyadjoint.ReducedFunctional or None
         """
         if self.reduced_functional is None:
             raise ValueError("Reduced functional not created.")
-        return self.reduced_functional.derivative(apply_riesz=False)
+        return _as_list(
+            self.reduced_functional.derivative(apply_riesz=False),
+        )
 
-    def verify_gradient(self, control_var, direction=None, dJdm=None):
+    def verify_gradient(
+        self, control_var: object, direction: object = None,
+        dJdm: object = None,
+    ) -> float:
         """Run a Taylor test to validate the automated-adjoint gradient.
 
         Performs pyadjoint's :func:`~pyadjoint.taylor_test`, which perturbs the
@@ -258,12 +303,12 @@ pyadjoint.ReducedFunctional or None
 
         Parameters
         ----------
-        control_var : firedrake.Function
-            The control about which the gradient is verified.
-        direction : firedrake.Function, optional
-            Perturbation direction. Defaults to a constant ``0.01`` field in the
-            control's function space.
-        dJdm : float, firedrake.Function, or firedrake.Cofunction, optional
+        control_var : firedrake.Function or iterable of firedrake.Function
+            Controls about which the gradient is verified.
+        direction : firedrake.Function or iterable of firedrake.Function, optional
+            Perturbation directions. Each defaults to a constant ``0.01``
+            field in the corresponding control's function space.
+        dJdm : float or iterable, optional
             The directional derivative ``J'(m)(direction)``. pyadjoint expects a
             scalar here, so if a gradient ``Function`` (Riesz representer) or a
             ``Cofunction`` (raw derivative) is supplied it is first paired with
@@ -284,9 +329,19 @@ pyadjoint.ReducedFunctional or None
         """
         if self.reduced_functional is None:
             raise ValueError("Reduced functional not created.")
+        control_var = _as_list(control_var)
         if direction is None:
-            direction = fire.Function(control_var.function_space())
-            direction.interpolate(0.01)
+            direction = []
+            for control in control_var:
+                perturbation = fire.Function(control.function_space())
+                perturbation.interpolate(0.01)
+                direction.append(perturbation)
+        else:
+            direction = _as_list(direction)
+        if len(control_var) != len(direction):
+            raise ValueError(
+                "Each control requires exactly one perturbation direction.",
+            )
         # pyadjoint's ``taylor_test`` expects ``dJdm`` to be the scalar
         # directional derivative ``J'(m)(h)``, not the gradient itself. When a
         # Firedrake ``Function`` (Riesz representer of the gradient) or a
@@ -296,14 +351,26 @@ pyadjoint.ReducedFunctional or None
         # ``min(residuals) < 1E-15`` raises ``UFL conditions cannot be
         # evaluated as bool in a Python context``.
         if dJdm is not None and not isinstance(dJdm, (int, float)):
-            if isinstance(dJdm, fire.Function):
-                dJdm = fire.assemble(
-                    fire.inner(dJdm, direction) * fire.dx
+            derivatives = _as_list(dJdm)
+            if len(derivatives) != len(direction):
+                raise ValueError(
+                    "Each control requires exactly one derivative.",
                 )
-            elif isinstance(dJdm, fire.Cofunction):
-                # Apply the cofunction to the direction (duality pairing).
-                dJdm = fire.assemble(fire.action(dJdm, direction))
+            directional_derivatives = []
+            for derivative, perturbation in zip(derivatives, direction):
+                if isinstance(derivative, fire.Function):
+                    directional_derivatives.append(
+                        fire.assemble(
+                            fire.inner(derivative, perturbation) * fire.dx,
+                        ),
+                    )
+                elif isinstance(derivative, fire.Cofunction):
+                    directional_derivatives.append(
+                        fire.assemble(fire.action(derivative, perturbation)),
+                    )
+                else:
+                    dJdm = None
+                    break
             else:
-                # Unknown type, fall back to pyadjoint's internal computation.
-                dJdm = None
+                dJdm = sum(directional_derivatives)
         return taylor_test(self.reduced_functional, control_var, direction, dJdm=dJdm)

--- a/spyro/solvers/automatic_differentiation_solver.py
+++ b/spyro/solvers/automatic_differentiation_solver.py
@@ -1,15 +1,12 @@
 from contextlib import contextmanager
 from collections.abc import Mapping
-from enum import Enum
 
 from pyadjoint import Tape, continue_annotation, pause_annotation, taylor_test
 
 import firedrake as fire
 import firedrake.adjoint as fire_ad
 
-from ..utils.physical_parameters import (ELASTIC_PARAMETERIZATIONS,
-                                         PhysicalParameters)
-from ..utils.typing import ElasticMaterialParameter
+from ..utils.physical_parameters import PhysicalParameters
 
 
 def _as_list(value: object) -> list:
@@ -150,11 +147,15 @@ pyadjoint.ReducedFunctional or None
     def set_control_parameters(self, parameters: object = None) -> None:
         """Select physical parameters for automated differentiation.
 
-        Control selection belongs to the adjoint solver. For isotropic elastic
-        waves, the selected parameters must form a non-empty subset of either
-        the Lame or velocity parameterization. Selecting the other family asks
-        the wave equation to change its physical parameterization before tape
-        recording.
+        Deciding *which* parameters to invert for belongs to the adjoint
+        solver; resolving them to independent fields belongs to the wave
+        equation, which is the only object that knows how its material
+        parameters are related. This method therefore forwards the selection
+        to :meth:`~spyro.solvers.wave.Wave.select_physical_parameters`, whose
+        subclasses raise on selections they cannot model.
+
+        The resolution may change the wave equation's physical
+        parameterization, which is why it must happen before tape recording.
 
         Parameters
         ----------
@@ -184,131 +185,8 @@ pyadjoint.ReducedFunctional or None
                 "Control parameters must be selected before tape recording.",
             )
 
-        physical_parameters = self.wave.physical_parameters
-        if all(
-            isinstance(name, ElasticMaterialParameter)
-            for name in physical_parameters
-        ):
-            selected = self._select_elastic_parameters(parameters)
-        else:
-            selected = self._select_independent_parameters(parameters)
-        self._set_controls(selected)
+        self._set_controls(self.wave.select_physical_parameters(parameters))
         self.reduced_functional = None
-
-    def _select_independent_parameters(
-        self, parameters: object,
-    ) -> PhysicalParameters:
-        """Resolve controls for a wave without coupled parameterizations.
-
-        Parameters
-        ----------
-        parameters : enum.Enum or iterable of enum.Enum, optional
-            Requested physical parameter names.
-
-        Returns
-        -------
-        PhysicalParameters
-            Selected names mapped to independent physical fields.
-        """
-        physical_parameters = self.wave.physical_parameters
-        if parameters is None:
-            selected_names = [
-                name for name, value in physical_parameters.items()
-                if isinstance(value, fire.Function)
-            ]
-        elif isinstance(parameters, Enum):
-            selected_names = [parameters]
-        else:
-            selected_names = list(parameters)
-
-        if not selected_names:
-            raise ValueError("At least one control parameter is required.")
-        if not all(isinstance(name, Enum) for name in selected_names):
-            raise TypeError(
-                "Control parameters must be material-parameter enum members.",
-            )
-        unknown = set(selected_names) - set(physical_parameters)
-        if unknown:
-            names = ", ".join(name.value for name in unknown)
-            raise ValueError(
-                f"Control parameters {{{names}}} are not physical "
-                "parameters of this wave equation.",
-            )
-
-        selected = PhysicalParameters()
-        for name in physical_parameters:
-            if name not in selected_names:
-                continue
-            field = physical_parameters[name]
-            if not isinstance(field, fire.Function):
-                raise TypeError(
-                    f"'{name.value}' is a dependent physical parameter and "
-                    "cannot be used directly as a control.",
-                )
-            selected.add(name, field)
-        return selected
-
-    def _select_elastic_parameters(
-        self, parameters: object,
-    ) -> PhysicalParameters:
-        """Resolve an independent isotropic-elastic control subset.
-
-        Parameters
-        ----------
-        parameters : ElasticMaterialParameter or iterable, optional
-            Requested elastic physical parameter names.
-
-        Returns
-        -------
-        PhysicalParameters
-            Selected names mapped to independent physical fields.
-        """
-        current = self.wave._physical_parameterization
-        if parameters is None:
-            selected_names = list(ELASTIC_PARAMETERIZATIONS[current])
-        elif isinstance(parameters, ElasticMaterialParameter):
-            selected_names = [parameters]
-        else:
-            selected_names = list(parameters)
-
-        if not selected_names:
-            raise ValueError("At least one elastic control parameter is required.")
-        if not all(
-            isinstance(name, ElasticMaterialParameter)
-            for name in selected_names
-        ):
-            raise TypeError(
-                "Elastic controls must be ElasticMaterialParameter enum "
-                "members.",
-            )
-        if len(set(selected_names)) != len(selected_names):
-            raise ValueError("Elastic control parameters must be unique.")
-
-        names = set(selected_names)
-        candidates = [
-            parameterization
-            for parameterization, family in ELASTIC_PARAMETERIZATIONS.items()
-            if names <= set(family)
-        ]
-        if not candidates:
-            formatted = ", ".join(name.value for name in selected_names)
-            raise ValueError(
-                "Elastic controls must be a subset of either "
-                "{density, lambda, mu} or "
-                "{density, p_wave_velocity, s_wave_velocity}; got "
-                f"{{{formatted}}}.",
-            )
-        target = current if current in candidates else candidates[0]
-        self.wave._set_physical_parameterization(target)
-
-        selected = PhysicalParameters()
-        for parameter in ELASTIC_PARAMETERIZATIONS[target]:
-            if parameter in names:
-                selected.add(
-                    parameter,
-                    self.wave.physical_parameters[parameter],
-                )
-        return selected
 
     @contextmanager
     def fresh_tape(self):

--- a/spyro/solvers/automatic_differentiation_solver.py
+++ b/spyro/solvers/automatic_differentiation_solver.py
@@ -1,10 +1,15 @@
 from contextlib import contextmanager
 from collections.abc import Mapping
+from enum import Enum
 
 from pyadjoint import Tape, continue_annotation, pause_annotation, taylor_test
 
 import firedrake as fire
 import firedrake.adjoint as fire_ad
+
+from ..utils.physical_parameters import (ELASTIC_PARAMETERIZATIONS,
+                                         PhysicalParameters)
+from ..utils.typing import ElasticMaterialParameter
 
 
 def _as_list(value: object) -> list:
@@ -67,7 +72,8 @@ class AutomatedAdjoint:
     ----------------
     .. code-block:: python
 
-        wave.enable_automated_adjoint()   # builds AutomatedAdjoint(wave.comm)
+        wave.enable_automated_adjoint()
+        wave.automated_adjoint.set_control_parameters(parameters)
         with wave.automated_adjoint.fresh_tape():
             wave.forward_solve()          # forward run recorded on the tape
         wave.automated_adjoint.create_reduced_functional(wave.functional_value)
@@ -77,14 +83,17 @@ class AutomatedAdjoint:
     Parameters
     ----------
     controls : object or iterable, optional
-        Controls with respect to which the functional is differentiated. A
-        labeled container such as ``PhysicalParameters`` may also be supplied.
-        Internally controls are always represented as a list.
+        Existing fields with respect to which the functional is differentiated.
+        This low-level argument is used when no wave is supplied.
     ensemble : firedrake.ensemble.Ensemble, optional
         The Firedrake ensemble communicator used to sum the per-shot
         functionals and gradients across ensemble members. In practice this is
         ``wave.comm``. If ``None``, a non-ensemble
         :class:`pyadjoint.ReducedFunctional` is used instead.
+    wave : Wave, optional
+        Wave equation whose physical parameters are available for selection.
+        When supplied, the adjoint solver selects the independent parameters
+        of the active physical parameterization by default.
 
     Attributes
     ----------
@@ -93,6 +102,8 @@ class AutomatedAdjoint:
     control_parameter_names : list
         Labels supplied by a control container, or ``None`` for unlabeled
         controls.
+    wave : Wave or None
+        Wave equation providing physical fields to the adjoint solver.
     ensemble : firedrake.ensemble.Ensemble or None
         The ensemble communicator used by the reduced functional.
     reduced_functional : firedrake.adjoint.EnsembleReducedFunctional or \
@@ -101,7 +112,32 @@ pyadjoint.ReducedFunctional or None
         :meth:`create_reduced_functional`.
     """
 
-    def __init__(self, ensemble: object, controls: object = None) -> None:
+    def __init__(
+        self, ensemble: object, controls: object = None, wave: object = None,
+    ) -> None:
+        self.wave = wave
+        self.controls = []
+        self.control_parameter_names = []
+        self.ensemble = ensemble
+        self.reduced_functional = None
+        self._tape = None
+        if wave is not None:
+            self.set_control_parameters()
+            return
+        self._set_controls(controls)
+
+    def _set_controls(self, controls: object) -> None:
+        """Store labeled or unlabeled control fields as ordered lists.
+
+        Parameters
+        ----------
+        controls : object or iterable
+            Control fields, optionally exposed through an ``items`` method.
+
+        Returns
+        -------
+        None
+        """
         try:
             control_items = list(controls.items())
         except AttributeError:
@@ -110,9 +146,169 @@ pyadjoint.ReducedFunctional or None
         else:
             self.control_parameter_names = [name for name, _ in control_items]
             self.controls = [value for _, value in control_items]
-        self.ensemble = ensemble
+
+    def set_control_parameters(self, parameters: object = None) -> None:
+        """Select physical parameters for automated differentiation.
+
+        Control selection belongs to the adjoint solver. For isotropic elastic
+        waves, the selected parameters must form a non-empty subset of either
+        the Lame or velocity parameterization. Selecting the other family asks
+        the wave equation to change its physical parameterization before tape
+        recording.
+
+        Parameters
+        ----------
+        parameters : enum.Enum or iterable of enum.Enum, optional
+            Physical parameters selected as controls. ``None`` selects every
+            independent parameter of the active physical parameterization.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        RuntimeError
+            If recording has already started.
+        ValueError
+            If no wave is attached or the selection is empty or inconsistent.
+        TypeError
+            If a selected name is not a material-parameter enum member.
+        """
+        if self.wave is None:
+            raise ValueError(
+                "A wave equation is required to select control parameters.",
+            )
+        if self._tape is not None:
+            raise RuntimeError(
+                "Control parameters must be selected before tape recording.",
+            )
+
+        physical_parameters = self.wave.physical_parameters
+        if all(
+            isinstance(name, ElasticMaterialParameter)
+            for name in physical_parameters
+        ):
+            selected = self._select_elastic_parameters(parameters)
+        else:
+            selected = self._select_independent_parameters(parameters)
+        self._set_controls(selected)
         self.reduced_functional = None
-        self._tape = None
+
+    def _select_independent_parameters(
+        self, parameters: object,
+    ) -> PhysicalParameters:
+        """Resolve controls for a wave without coupled parameterizations.
+
+        Parameters
+        ----------
+        parameters : enum.Enum or iterable of enum.Enum, optional
+            Requested physical parameter names.
+
+        Returns
+        -------
+        PhysicalParameters
+            Selected names mapped to independent physical fields.
+        """
+        physical_parameters = self.wave.physical_parameters
+        if parameters is None:
+            selected_names = [
+                name for name, value in physical_parameters.items()
+                if isinstance(value, fire.Function)
+            ]
+        elif isinstance(parameters, Enum):
+            selected_names = [parameters]
+        else:
+            selected_names = list(parameters)
+
+        if not selected_names:
+            raise ValueError("At least one control parameter is required.")
+        if not all(isinstance(name, Enum) for name in selected_names):
+            raise TypeError(
+                "Control parameters must be material-parameter enum members.",
+            )
+        unknown = set(selected_names) - set(physical_parameters)
+        if unknown:
+            names = ", ".join(name.value for name in unknown)
+            raise ValueError(
+                f"Control parameters {{{names}}} are not physical "
+                "parameters of this wave equation.",
+            )
+
+        selected = PhysicalParameters()
+        for name in physical_parameters:
+            if name not in selected_names:
+                continue
+            field = physical_parameters[name]
+            if not isinstance(field, fire.Function):
+                raise TypeError(
+                    f"'{name.value}' is a dependent physical parameter and "
+                    "cannot be used directly as a control.",
+                )
+            selected.add(name, field)
+        return selected
+
+    def _select_elastic_parameters(
+        self, parameters: object,
+    ) -> PhysicalParameters:
+        """Resolve an independent isotropic-elastic control subset.
+
+        Parameters
+        ----------
+        parameters : ElasticMaterialParameter or iterable, optional
+            Requested elastic physical parameter names.
+
+        Returns
+        -------
+        PhysicalParameters
+            Selected names mapped to independent physical fields.
+        """
+        current = self.wave._physical_parameterization
+        if parameters is None:
+            selected_names = list(ELASTIC_PARAMETERIZATIONS[current])
+        elif isinstance(parameters, ElasticMaterialParameter):
+            selected_names = [parameters]
+        else:
+            selected_names = list(parameters)
+
+        if not selected_names:
+            raise ValueError("At least one elastic control parameter is required.")
+        if not all(
+            isinstance(name, ElasticMaterialParameter)
+            for name in selected_names
+        ):
+            raise TypeError(
+                "Elastic controls must be ElasticMaterialParameter enum "
+                "members.",
+            )
+        if len(set(selected_names)) != len(selected_names):
+            raise ValueError("Elastic control parameters must be unique.")
+
+        names = set(selected_names)
+        candidates = [
+            parameterization
+            for parameterization, family in ELASTIC_PARAMETERIZATIONS.items()
+            if names <= set(family)
+        ]
+        if not candidates:
+            formatted = ", ".join(name.value for name in selected_names)
+            raise ValueError(
+                "Elastic controls must be a subset of either "
+                "{density, lambda, mu} or "
+                "{density, p_wave_velocity, s_wave_velocity}; got "
+                f"{{{formatted}}}.",
+            )
+        target = current if current in candidates else candidates[0]
+        self.wave._set_physical_parameterization(target)
+
+        selected = PhysicalParameters()
+        for parameter in ELASTIC_PARAMETERIZATIONS[target]:
+            if parameter in names:
+                selected.add(
+                    parameter,
+                    self.wave.physical_parameters[parameter],
+                )
+        return selected
 
     @contextmanager
     def fresh_tape(self):
@@ -286,6 +482,34 @@ pyadjoint.ReducedFunctional or None
         return _as_list(
             self.reduced_functional.derivative(apply_riesz=False),
         )
+
+    def label_derivatives(self, derivatives: object) -> PhysicalParameters:
+        """Associate computed derivatives with selected physical parameters.
+
+        Parameters
+        ----------
+        derivatives : object or iterable
+            Derivatives positionally matching :attr:`controls`.
+
+        Returns
+        -------
+        PhysicalParameters
+            Derivatives keyed by their selected physical parameter enums.
+
+        Raises
+        ------
+        ValueError
+            If the controls were supplied without physical parameter labels.
+        """
+        if any(name is None for name in self.control_parameter_names):
+            raise ValueError(
+                "Physical parameter labels are required for labeled "
+                "derivatives.",
+            )
+        return PhysicalParameters(zip(
+            self.control_parameter_names,
+            _as_list(derivatives),
+        ))
 
     def verify_gradient(
         self, control_var: object, direction: object = None,

--- a/spyro/solvers/automatic_differentiation_solver.py
+++ b/spyro/solvers/automatic_differentiation_solver.py
@@ -69,8 +69,7 @@ class AutomatedAdjoint:
     ----------------
     .. code-block:: python
 
-        wave.enable_automated_adjoint()
-        wave.automated_adjoint.set_control_parameters(parameters)
+        wave.enable_automated_adjoint(control_parameters=parameters)
         with wave.automated_adjoint.fresh_tape():
             wave.forward_solve()          # forward run recorded on the tape
         wave.automated_adjoint.create_reduced_functional(wave.functional_value)
@@ -79,19 +78,17 @@ class AutomatedAdjoint:
 
     Parameters
     ----------
-    controls : object or iterable, optional
-        Existing fields with respect to which the functional is differentiated.
-        This low-level argument is used when no wave is supplied.
+    controls : object, mapping, or iterable, optional
+        Fields with respect to which the functional is differentiated. A
+        mapping keyed by material parameters labels its controls, so the
+        derivatives can be handed back under the same names; anything else is
+        taken as unlabeled fields. The wave equation resolves parameter names
+        to these fields before constructing the adjoint solver.
     ensemble : firedrake.ensemble.Ensemble, optional
         The Firedrake ensemble communicator used to sum the per-shot
         functionals and gradients across ensemble members. In practice this is
         ``wave.comm``. If ``None``, a non-ensemble
         :class:`pyadjoint.ReducedFunctional` is used instead.
-    select_parameters : callable, optional
-        Resolves selected physical parameter names to the fields carrying
-        them, normally
-        the wave equation's own parameter selection. When supplied, every parameter the
-        equation offers is selected by default.
 
     Attributes
     ----------
@@ -108,22 +105,12 @@ pyadjoint.ReducedFunctional or None
         :meth:`create_reduced_functional`.
     """
 
-    def __init__(
-        self, ensemble: object, controls: object = None,
-        select_parameters: object = None,
-    ) -> None:
+    def __init__(self, ensemble: object, controls: object = None) -> None:
         self.controls = []
         self.control_parameter_names = []
         self.ensemble = ensemble
         self.reduced_functional = None
         self._tape = None
-        #: Resolves parameter names to fields. This is all the adjoint solver
-        #: needs from the equation it differentiates, so it holds the one
-        #: function rather than the whole solver.
-        self._select_parameters = select_parameters
-        if select_parameters is not None:
-            self.set_control_parameters()
-            return
         self._set_controls(controls)
 
     def _set_controls(self, controls: object) -> None:
@@ -146,50 +133,6 @@ pyadjoint.ReducedFunctional or None
         else:
             self.control_parameter_names = [name for name, _ in control_items]
             self.controls = [value for _, value in control_items]
-
-    def set_control_parameters(self, parameters: object = None) -> None:
-        """Select physical parameters for automated differentiation.
-
-        Deciding *which* parameters to invert for belongs to the adjoint
-        solver; resolving them to independent fields belongs to the wave
-        equation, which is the only object that knows how its material
-        parameters are related. This method therefore forwards the selection
-        to the equation's ``select_parameters``, which raises on selections
-        it cannot offer.
-
-        The resolution may change the wave equation's physical
-        parameterization, which is why it must happen before tape recording.
-
-        Parameters
-        ----------
-        parameters : enum.Enum or iterable of enum.Enum, optional
-            Physical parameters selected as controls. ``None`` selects every
-            independent parameter of the active physical parameterization.
-
-        Returns
-        -------
-        None
-
-        Raises
-        ------
-        RuntimeError
-            If recording has already started.
-        ValueError
-            If no wave is attached or the selection is empty or inconsistent.
-        TypeError
-            If a selected name is not a material-parameter enum member.
-        """
-        if self._select_parameters is None:
-            raise ValueError(
-                "A wave equation is required to select control parameters.",
-            )
-        if self._tape is not None:
-            raise RuntimeError(
-                "Control parameters must be selected before tape recording.",
-            )
-
-        self._set_controls(self._select_parameters(parameters))
-        self.reduced_functional = None
 
     @contextmanager
     def fresh_tape(self):

--- a/spyro/solvers/automatic_differentiation_solver.py
+++ b/spyro/solvers/automatic_differentiation_solver.py
@@ -87,10 +87,11 @@ class AutomatedAdjoint:
         functionals and gradients across ensemble members. In practice this is
         ``wave.comm``. If ``None``, a non-ensemble
         :class:`pyadjoint.ReducedFunctional` is used instead.
-    wave : Wave, optional
-        Wave equation whose physical parameters are available for selection.
-        When supplied, the adjoint solver selects the independent parameters
-        of the active physical parameterization by default.
+    select_parameters : callable, optional
+        Resolves selected physical parameter names to the fields carrying
+        them, normally
+        the wave equation's own parameter selection. When supplied, every parameter the
+        equation offers is selected by default.
 
     Attributes
     ----------
@@ -99,8 +100,6 @@ class AutomatedAdjoint:
     control_parameter_names : list
         Labels supplied by a control container, or ``None`` for unlabeled
         controls.
-    wave : Wave or None
-        Wave equation providing physical fields to the adjoint solver.
     ensemble : firedrake.ensemble.Ensemble or None
         The ensemble communicator used by the reduced functional.
     reduced_functional : firedrake.adjoint.EnsembleReducedFunctional or \
@@ -110,15 +109,19 @@ pyadjoint.ReducedFunctional or None
     """
 
     def __init__(
-        self, ensemble: object, controls: object = None, wave: object = None,
+        self, ensemble: object, controls: object = None,
+        select_parameters: object = None,
     ) -> None:
-        self.wave = wave
         self.controls = []
         self.control_parameter_names = []
         self.ensemble = ensemble
         self.reduced_functional = None
         self._tape = None
-        if wave is not None:
+        #: Resolves parameter names to fields. This is all the adjoint solver
+        #: needs from the equation it differentiates, so it holds the one
+        #: function rather than the whole solver.
+        self._select_parameters = select_parameters
+        if select_parameters is not None:
             self.set_control_parameters()
             return
         self._set_controls(controls)
@@ -151,8 +154,8 @@ pyadjoint.ReducedFunctional or None
         solver; resolving them to independent fields belongs to the wave
         equation, which is the only object that knows how its material
         parameters are related. This method therefore forwards the selection
-        to :meth:`~spyro.solvers.wave.Wave.select_physical_parameters`, whose
-        subclasses raise on selections they cannot model.
+        to the equation's ``select_parameters``, which raises on selections
+        it cannot offer.
 
         The resolution may change the wave equation's physical
         parameterization, which is why it must happen before tape recording.
@@ -176,7 +179,7 @@ pyadjoint.ReducedFunctional or None
         TypeError
             If a selected name is not a material-parameter enum member.
         """
-        if self.wave is None:
+        if self._select_parameters is None:
             raise ValueError(
                 "A wave equation is required to select control parameters.",
             )
@@ -185,7 +188,7 @@ pyadjoint.ReducedFunctional or None
                 "Control parameters must be selected before tape recording.",
             )
 
-        self._set_controls(self.wave.select_physical_parameters(parameters))
+        self._set_controls(self._select_parameters(parameters))
         self.reduced_functional = None
 
     @contextmanager

--- a/spyro/solvers/elastic_wave/elastic_wave.py
+++ b/spyro/solvers/elastic_wave/elastic_wave.py
@@ -53,6 +53,49 @@ class ElasticWave(Wave, metaclass=ABCMeta):
     def initialize_model_parameters_from_file(self, synthetic_data_dict):
         pass
 
+    def set_physical_parameterization(self, parameterization) -> None:
+        """Set which elastic parameters carry the material data.
+
+        An elastic medium is described by more than one set of physical
+        parameters -- an isotropic one by density with the Lame parameters,
+        or by density with the two wave speeds. The solver reads all of them
+        whatever this is set to; what it chooses is which ones hold the data
+        as fields, the rest being expressions computed from those.
+
+        Only a field has degrees of freedom to perturb, so this decides what
+        can be differentiated with respect to, not what the equation is
+        solved for. It is a decision about the equation, made before any
+        parameter is selected as a control.
+
+        Initializing the material properties already picks a set, by reading
+        whichever one the model input declares. This method is public because
+        that first choice is worth revising: an inversion is not obliged to
+        invert in the parameters its model happens to be stored in, and which
+        set it uses changes the conditioning of the problem and the cross-talk
+        between parameters. Exposing the change of variables keeps it in the
+        solver, where it is the same one initialization performs, rather than
+        leaving callers to convert their model input by hand and get a factor
+        or a sign wrong.
+
+        Parameters
+        ----------
+        parameterization : enum.Enum
+            Set of elastic parameters to carry the data.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        NotImplementedError
+            Always, unless a subclass implements it.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement a change of physical "
+            "parameterization.",
+        )
+
     def gradient_solve(self, guess=None, misfit=None, forward_solution=None):
         raise NotImplementedError(
             "Elastic adjoint gradients are not implemented yet.",

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -65,10 +65,20 @@ class IsotropicWave(ElasticWave):
         self.mu = None    # Second Lame parameter
         self.c_s = None   # Secondary wave velocity
         self._physical_parameterization = None
-        #: Family whose independent fields already exist as ``Function``
-        #: objects owned by this solver rather than by the model dictionary.
-        self._materialized_parameterization = None
-        self._material_parameter_function_space = None
+        #: Whether the physical parameters already exist as the ``Function``
+        #: objects this solver goes on using.
+        #:
+        #: Every forward solve re-reads the model dictionary and builds new
+        #: ``Function`` objects from it. While the dictionary is the source
+        #: of truth, that is harmless: the same numbers go in and come back
+        #: out. It stops being harmless once the automated adjoint has run,
+        #: because by then two things live inside those particular objects.
+        #: The pyadjoint controls refer to them by identity, and an
+        #: inversion has written its current iterate into them. A rebuild
+        #: would leave the controls pointing at objects the solve no longer
+        #: uses, and reset the iterate to the model's initial values. So
+        #: from that point on the rebuild is skipped.
+        self._physical_parameters_are_built = False
 
         self.u_n = None   # Current displacement field
         self.u_nm1 = None  # Displacement field in previous iteration
@@ -106,12 +116,10 @@ class IsotropicWave(ElasticWave):
         from the provided set, and the active physical parameterization is
         stored.
 
-        Every forward solve calls this method again. Once a family has been
-        materialized by :meth:`_set_physical_parameterization` the independent
-        fields are owned by this solver, so they are kept as they are rather
-        than rebuilt from the dictionary: they hold the current values, and
-        rebuilding them would break the identity that pyadjoint controls and
-        already assembled forms rely on.
+        Every forward solve calls this method again. Once
+        :meth:`_set_physical_parameterization` has built the physical
+        parameters the rebuild is skipped, so the objects the adjoint and any
+        inversion depend on survive; see ``_physical_parameters_are_built``.
 
         Parameters
         ----------
@@ -129,7 +137,7 @@ class IsotropicWave(ElasticWave):
             The method assigns ``rho``, ``lmbda``, ``mu``, ``c``, ``c_s``, and
             the active physical parameterization on ``self``.
         """
-        if self._materialized_parameterization is not None:
+        if self._physical_parameters_are_built:
             return
 
         def material_parameter(value):
@@ -220,31 +228,6 @@ class IsotropicWave(ElasticWave):
         add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
         add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
 
-    def _material_parameter_space(self) -> object:
-        """Return the scalar space used for material parameters.
-
-        Returns
-        -------
-        firedrake.FunctionSpace
-            Scalar finite-element space on the elastic mesh.
-
-        Raises
-        ------
-        ValueError
-            If the mesh has not been created.
-        """
-        if self.mesh is None:
-            raise ValueError(
-                "Mesh must be set before creating elastic material fields.",
-            )
-        space = self._material_parameter_function_space
-        if space is None or space.mesh() is not self.mesh:
-            space = create_function_space(
-                self.mesh, self.method, self.degree, dim=1,
-            )
-            self._material_parameter_function_space = space
-        return space
-
     def _set_physical_parameterization(
         self, parameterization: ElasticMaterialParameterization,
     ) -> None:
@@ -258,9 +241,8 @@ class IsotropicWave(ElasticWave):
         Once a family has been materialized the fields belong to this object
         rather than to the model dictionary: they may be registered as
         pyadjoint controls, and rebuilding them from the dictionary would
-        both discard the current values and orphan those controls. This is
-        why ``_materialized_parameterization`` makes
-        :meth:`initialize_model_parameters_from_object` keep them.
+        both discard the current values and orphan those controls, which is
+        why this sets ``_physical_parameters_are_built``.
 
         Parameters
         ----------
@@ -274,9 +256,17 @@ class IsotropicWave(ElasticWave):
         Raises
         ------
         ValueError
-            If the family is not one this solver supports.
+            If the mesh has not been created, or the family is not one this
+            solver supports.
         """
-        space = self._material_parameter_space()
+        if self.mesh is None:
+            raise ValueError(
+                "Mesh must be set before creating elastic physical "
+                "parameters.",
+            )
+        space = create_function_space(
+            self.mesh, self.method, self.degree, dim=1,
+        )
 
         def as_field(value, parameter):
             """Return ``value`` as an independent field of ``parameter``."""
@@ -307,7 +297,7 @@ class IsotropicWave(ElasticWave):
             )
 
         self._physical_parameterization = parameterization
-        self._materialized_parameterization = parameterization
+        self._physical_parameters_are_built = True
         add = self._physical_parameters.add
         add(ElasticMaterialParameter.DENSITY, self.rho)
         add(ElasticMaterialParameter.LAMBDA, self.lmbda)

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -266,16 +266,29 @@ class IsotropicWave(ElasticWave):
     ) -> PhysicalParameters:
         """Compute automated-adjoint elastic material derivatives.
 
+        Only the automated adjoint is available for the elastic wave so far.
+        The implemented adjoint -- the backward integration written out by
+        hand, which the acoustic solver already offers -- is intended to
+        follow, and ``misfit`` and ``forward_solution`` are the two inputs it
+        needs. They are part of the signature so that callers written against
+        :meth:`~spyro.solvers.acoustic_wave.AcousticWave.gradient_solve` keep
+        working once it lands, and are unused until then.
+
         Parameters
         ----------
         misfit : array_like, optional
-            Accepted for compatibility; the recorded functional owns the
-            elastic misfit.
+            Difference between observed and simulated receiver data. The
+            implemented adjoint drives the backward equation with it. The
+            automated adjoint does not need it: it differentiates the
+            functional recorded during the forward solve, which already
+            accumulated the misfit.
         forward_solution : firedrake.Function, optional
-            Accepted for compatibility; the automated adjoint recovers the
-            forward wavefield on its own.
+            Forward wavefield. The implemented adjoint integrates the adjoint
+            equation backwards against it, so passing it saves a forward
+            solve. The automated adjoint recovers the wavefield on its own.
         adjoint_type : AdjointType, optional
-            Must be :attr:`AdjointType.AUTOMATED_ADJOINT`.
+            Must be :attr:`AdjointType.AUTOMATED_ADJOINT` until the
+            implemented adjoint is available for elastic waves.
         riesz_map : RieszMapType, optional
             ``L2`` returns primal gradients and ``l2`` raw derivatives.
 

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -141,7 +141,7 @@ class IsotropicWave(ElasticWave):
         self.c_s = declared(ElasticMaterialParameter.S_WAVE_VELOCITY)
 
         # Exactly one set must be declared, and it names the parameters
-        # the equation is solved in terms of. ``is not None`` rather than
+        # that carry the material data. ``is not None`` rather than
         # truthiness:
         # every UFL object is unconditionally true, so ``bool`` would only
         # ever be testing whether the key was present.
@@ -186,12 +186,15 @@ class IsotropicWave(ElasticWave):
     def set_physical_parameterization(
         self, parameterization: ElasticMaterialParameterization,
     ) -> None:
-        """Set which elastic parameters the equation is solved in terms of.
+        """Set which elastic parameters carry the material data.
 
-        The chosen set becomes three scalar ``Function`` objects and the
-        complementary set is relinked to them through UFL expressions, so
-        updating one of the chosen parameters carries through to the ones
-        computed from it and to the assembled variational forms.
+        All five are read whatever this is set to: the variational form is
+        written in density and the Lame parameters, while the absorbing
+        boundary conditions and the stable timestep estimate are written in
+        the two wave speeds. The chosen three become scalar ``Function``
+        objects and the other two become UFL expressions of them, recomputed
+        wherever they appear, so updating one of the chosen parameters
+        carries through to the computed ones and to the assembled forms.
 
         This is a change of variables on the solver, not an edit of the
         model: the input dictionary is left as the user wrote it, and the
@@ -201,7 +204,7 @@ class IsotropicWave(ElasticWave):
         Parameters
         ----------
         parameterization : ElasticMaterialParameterization
-            Set of elastic parameters to solve in terms of.
+            Set of elastic parameters to carry the data.
 
         Returns
         -------
@@ -222,7 +225,7 @@ class IsotropicWave(ElasticWave):
 
             Before a mesh exists there is no space to build a ``Function``
             in, so the value is left as the scalar or ``Constant`` it came
-            in as, and the equation is still solved in terms of this set.
+            in as, and this set still carries the data.
             """
             if space is None or isinstance(value, Function):
                 return value

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -64,20 +64,6 @@ class IsotropicWave(ElasticWave):
         self.lmbda = None  # First Lame parameter
         self.mu = None    # Second Lame parameter
         self.c_s = None   # Secondary wave velocity
-        self._physical_parameterization = None
-        #: Whether the physical parameters already exist as the ``Function``
-        #: objects this solver goes on using.
-        #:
-        #: Every forward solve re-reads the model dictionary and builds new
-        #: ``Function`` objects from it. While the dictionary is the source
-        #: of truth, that is harmless: the same numbers go in and come back
-        #: out. It stops being harmless once the adjoint equation has been
-        #: set up, because the adjoint is posed with respect to those exact
-        #: objects, and an inversion has written its current iterate into
-        #: them. A rebuild would differentiate with respect to objects the
-        #: forward solve no longer uses, and reset the iterate to the
-        #: model's initial values. So from that point on it is skipped.
-        self._physical_parameters_are_built = False
 
         self.u_n = None   # Current displacement field
         self.u_nm1 = None  # Displacement field in previous iteration
@@ -271,82 +257,6 @@ class IsotropicWave(ElasticWave):
         add(ElasticMaterialParameter.MU, self.mu)
         add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
         add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
-
-    def set_physical_parameterization(
-        self, parameterization: ElasticMaterialParameterization,
-    ) -> None:
-        """Write the equation in one of its physical parameter families.
-
-        An isotropic elastic medium can be written in terms of
-        ``{density, lambda, mu}`` or of
-        ``{density, p_wave_velocity, s_wave_velocity}``, carrying whichever
-        family it is not written in as expressions of the other. Choosing
-        between them is a decision about the equation, so it belongs here
-        rather than to whatever differentiates it, and it has to be made
-        before parameters are selected as controls.
-
-        The choice is deliberate, so it also pins the fields: the model
-        dictionary declares one family, and letting the next initialization
-        read it again would silently undo this call.
-
-        Parameters
-        ----------
-        parameterization : ElasticMaterialParameterization
-            Family to write the equation in.
-
-        Returns
-        -------
-        None
-
-        Raises
-        ------
-        ValueError
-            If the family is not one this solver supports.
-        """
-        self._build_physical_parameterization(parameterization)
-        self._physical_parameters_are_built = True
-
-    def select_physical_parameters(
-        self, names: object = None,
-    ) -> PhysicalParameters:
-        """Select controls from the family the equation is written in.
-
-        The equation is written in one family and carries the other as
-        expressions of it, so only the family in use can be controlled.
-        Changing that is :meth:`set_physical_parameterization`, a decision
-        about the equation rather than about the inversion, and it has to be
-        made before parameters are selected.
-
-        Parameters
-        ----------
-        names : ElasticMaterialParameter or iterable, optional
-            Elastic parameters to resolve. ``None`` selects the whole family
-            the equation is currently written in.
-
-        Returns
-        -------
-        PhysicalParameters
-            Selected names, mapped to the fields carrying them.
-
-        Raises
-        ------
-        ValueError
-            If no mesh exists yet, or the selection is empty.
-        TypeError
-            If a name is not an :class:`ElasticMaterialParameter` member, or
-            belongs to the family the equation is not written in.
-        """
-        if self.mesh is None:
-            raise ValueError(
-                "Mesh must be set before selecting elastic physical "
-                "parameters: a control has to be a field.",
-            )
-        selected = super().select_physical_parameters(names)
-        # The selected fields are about to be differentiated with respect to,
-        # or written into by an inversion. Either way the model dictionary
-        # must stop rebuilding them; see ``_physical_parameters_are_built``.
-        self._physical_parameters_are_built = True
-        return selected
 
     def gradient_solve(
         self,

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -250,7 +250,6 @@ class IsotropicWave(ElasticWave):
                 f"{parameterization}.",
             )
 
-        self._physical_parameterization = parameterization
         add = self._physical_parameters.add
         add(ElasticMaterialParameter.DENSITY, self.rho)
         add(ElasticMaterialParameter.LAMBDA, self.lmbda)

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -97,14 +97,15 @@ class IsotropicWave(ElasticWave):
 
         The dictionary must define exactly one supported material
         parameterization: either density with Lame parameters, or density with
-        P- and S-wave velocities. The missing dependent parameters are computed
-        from the provided set, and the active physical parameterization is
-        stored.
+        P- and S-wave velocities. The missing dependent parameters are
+        computed from the provided set.
 
-        Every forward solve calls this method again. Once
-        :meth:`set_physical_parameterization` has built the physical
-        parameters the rebuild is skipped, so the objects the adjoint and any
-        inversion depend on survive; see ``_physical_parameters_are_built``.
+        Every forward solve calls this method again, so it only reads the
+        model once: the parameters it built the first time are the objects
+        the assembled forms, the adjoint and any inversion refer to, and
+        rebuilding them would replace those objects and reset an inversion's
+        current iterate to the model's initial values. Replacing the model
+        clears the parameters, which is what allows them to be built again.
 
         Parameters
         ----------
@@ -122,7 +123,7 @@ class IsotropicWave(ElasticWave):
             The method assigns ``rho``, ``lmbda``, ``mu``, ``c``, ``c_s``, and
             the active physical parameterization on ``self``.
         """
-        if self._physical_parameters_are_built:
+        if self._physical_parameters:
             return
 
         def declared(parameter, *aliases):
@@ -139,8 +140,9 @@ class IsotropicWave(ElasticWave):
         self.c = declared(ElasticMaterialParameter.P_WAVE_VELOCITY)
         self.c_s = declared(ElasticMaterialParameter.S_WAVE_VELOCITY)
 
-        # Exactly one family must be declared, and it names the family the
-        # equation is written in. ``is not None`` rather than truthiness:
+        # Exactly one set must be declared, and it names the parameters
+        # the equation is solved in terms of. ``is not None`` rather than
+        # truthiness:
         # every UFL object is unconditionally true, so ``bool`` would only
         # ever be testing whether the key was present.
         lame = (
@@ -165,9 +167,9 @@ class IsotropicWave(ElasticWave):
                 ElasticMaterialParameterization.VELOCITY
             )
         else:
-            families = " or (exclusive) ".join(
-                _format_physical_parameters(family)
-                for family in PHYSICAL_PARAMETERIZATION.values()
+            options = " or (exclusive) ".join(
+                _format_physical_parameters(parameters)
+                for parameters in PHYSICAL_PARAMETERIZATION.values()
             )
             raise ValueError(
                 "Inconsistent selection of isotropic elastic wave "
@@ -177,31 +179,29 @@ class IsotropicWave(ElasticWave):
                 f"    Lame second    : {self.mu is not None}\n"
                 f"    P-wave velocity: {self.c is not None}\n"
                 f"    S-wave velocity: {self.c_s is not None}\n"
-                f"The valid options are {families}",
+                f"The valid options are {options}",
             )
-        self._build_physical_parameterization(declared_parameterization)
+        self.set_physical_parameterization(declared_parameterization)
 
-    def _build_physical_parameterization(
+    def set_physical_parameterization(
         self, parameterization: ElasticMaterialParameterization,
     ) -> None:
-        """Materialize one independent elastic parameter family.
+        """Set which elastic parameters the equation is solved in terms of.
 
-        The target family becomes three scalar ``Function`` objects and the
-        complementary family is relinked to them through UFL expressions, so
-        updating an independent field carries through to the dependent ones
-        and to the assembled variational forms.
+        The chosen set becomes three scalar ``Function`` objects and the
+        complementary set is relinked to them through UFL expressions, so
+        updating one of the chosen parameters carries through to the ones
+        computed from it and to the assembled variational forms.
 
-        Once a family has been materialized the fields belong to this object
-        rather than to the model dictionary: the adjoint equation may already
-        be posed with respect to them, and rebuilding them from the
-        dictionary would both discard the current values and leave that
-        adjoint differentiating unused fields, which is why this sets
-        ``_physical_parameters_are_built``.
+        This is a change of variables on the solver, not an edit of the
+        model: the input dictionary is left as the user wrote it, and the
+        set chosen here survives because initialization does not read the
+        model a second time.
 
         Parameters
         ----------
         parameterization : ElasticMaterialParameterization
-            Independent physical parameter family to materialize.
+            Set of elastic parameters to solve in terms of.
 
         Returns
         -------
@@ -210,8 +210,8 @@ class IsotropicWave(ElasticWave):
         Raises
         ------
         ValueError
-            If the mesh has not been created, or the family is not one this
-            solver supports.
+            If the mesh has not been created, or the set of parameters is
+            not one this solver supports.
         """
         space = None if self.mesh is None else create_function_space(
             self.mesh, self.method, self.degree, dim=1,
@@ -222,7 +222,7 @@ class IsotropicWave(ElasticWave):
 
             Before a mesh exists there is no space to build a ``Function``
             in, so the value is left as the scalar or ``Constant`` it came
-            in as and the equation is still written in this family.
+            in as, and the equation is still solved in terms of this set.
             """
             if space is None or isinstance(value, Function):
                 return value

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -116,7 +116,7 @@ class IsotropicWave(ElasticWave):
         stored.
 
         Every forward solve calls this method again. Once
-        :meth:`_set_physical_parameterization` has built the physical
+        :meth:`set_physical_parameterization` has built the physical
         parameters the rebuild is skipped, so the objects the adjoint and any
         inversion depend on survive; see ``_physical_parameters_are_built``.
 
@@ -193,9 +193,9 @@ class IsotropicWave(ElasticWave):
                 f"    S-wave velocity: {self.c_s is not None}\n"
                 f"The valid options are {families}",
             )
-        self._set_physical_parameterization(declared_parameterization)
+        self._build_physical_parameterization(declared_parameterization)
 
-    def _set_physical_parameterization(
+    def _build_physical_parameterization(
         self, parameterization: ElasticMaterialParameterization,
     ) -> None:
         """Materialize one independent elastic parameter family.
@@ -272,18 +272,50 @@ class IsotropicWave(ElasticWave):
         add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
         add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
 
+    def set_physical_parameterization(
+        self, parameterization: ElasticMaterialParameterization,
+    ) -> None:
+        """Write the equation in one of its physical parameter families.
+
+        An isotropic elastic medium can be written in terms of
+        ``{density, lambda, mu}`` or of
+        ``{density, p_wave_velocity, s_wave_velocity}``, carrying whichever
+        family it is not written in as expressions of the other. Choosing
+        between them is a decision about the equation, so it belongs here
+        rather than to whatever differentiates it, and it has to be made
+        before parameters are selected as controls.
+
+        The choice is deliberate, so it also pins the fields: the model
+        dictionary declares one family, and letting the next initialization
+        read it again would silently undo this call.
+
+        Parameters
+        ----------
+        parameterization : ElasticMaterialParameterization
+            Family to write the equation in.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        ValueError
+            If the family is not one this solver supports.
+        """
+        self._build_physical_parameterization(parameterization)
+        self._physical_parameters_are_built = True
+
     def select_physical_parameters(
         self, names: object = None,
     ) -> PhysicalParameters:
-        """Resolve an independent isotropic-elastic selection.
+        """Select controls from the family the equation is written in.
 
-        An isotropic elastic medium is written either in terms of
-        ``{density, lambda, mu}`` or of
-        ``{density, p_wave_velocity, s_wave_velocity}``, and carries the family
-        it is not written in as expressions of the other. A selection is
-        therefore valid when it fits inside one family, and asking for names
-        from the family currently held as expressions changes the equation over
-        to it.
+        The equation is written in one family and carries the other as
+        expressions of it, so only the family in use can be controlled.
+        Changing that is :meth:`set_physical_parameterization`, a decision
+        about the equation rather than about the inversion, and it has to be
+        made before parameters are selected.
 
         Parameters
         ----------
@@ -294,70 +326,26 @@ class IsotropicWave(ElasticWave):
         Returns
         -------
         PhysicalParameters
-            Selected names, mapped to the independent fields carrying them.
+            Selected names, mapped to the fields carrying them.
 
         Raises
         ------
         ValueError
-            If the selection is empty, repeats a name, or spans both families.
+            If no mesh exists yet, or the selection is empty.
         TypeError
-            If a name is not an :class:`ElasticMaterialParameter` member.
+            If a name is not an :class:`ElasticMaterialParameter` member, or
+            belongs to the family the equation is not written in.
         """
-        current = self._physical_parameterization
-        if current is None:
-            raise ValueError(
-                "Elastic material parameters have not been initialized. "
-                "Call initialize_physical_parameters() first.",
-            )
-        if names is None:
-            selected_names = list(PHYSICAL_PARAMETERIZATION[current])
-        elif isinstance(names, ElasticMaterialParameter):
-            selected_names = [names]
-        else:
-            selected_names = list(names)
-
-        if not selected_names:
-            raise ValueError("At least one elastic control parameter is required.")
-        if not all(
-            isinstance(name, ElasticMaterialParameter)
-            for name in selected_names
-        ):
-            raise TypeError(
-                "Elastic controls must be ElasticMaterialParameter enum "
-                "members.",
-            )
-        if len(set(selected_names)) != len(selected_names):
-            raise ValueError("Elastic control parameters must be unique.")
-
-        wanted = set(selected_names)
-        candidates = [
-            parameterization
-            for parameterization, family in PHYSICAL_PARAMETERIZATION.items()
-            if wanted <= set(family)
-        ]
-        if not candidates:
-            families = " or ".join(
-                _format_physical_parameters(family)
-                for family in PHYSICAL_PARAMETERIZATION.values()
-            )
-            raise ValueError(
-                f"Elastic controls must be a subset of either {families}; "
-                f"got {_format_physical_parameters(selected_names)}.",
-            )
-        target = current if current in candidates else candidates[0]
         if self.mesh is None:
             raise ValueError(
                 "Mesh must be set before selecting elastic physical "
                 "parameters: a control has to be a field.",
             )
-        self._set_physical_parameterization(target)
-        # From here on the fields are this solver's own; see the attribute.
+        selected = super().select_physical_parameters(names)
+        # The selected fields are about to be differentiated with respect to,
+        # or written into by an inversion. Either way the model dictionary
+        # must stop rebuilding them; see ``_physical_parameters_are_built``.
         self._physical_parameters_are_built = True
-
-        selected = PhysicalParameters()
-        for parameter in PHYSICAL_PARAMETERIZATION[target]:
-            if parameter in wanted:
-                selected.add(parameter, self.physical_parameters[parameter])
         return selected
 
     def gradient_solve(

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -71,13 +71,12 @@ class IsotropicWave(ElasticWave):
         #: Every forward solve re-reads the model dictionary and builds new
         #: ``Function`` objects from it. While the dictionary is the source
         #: of truth, that is harmless: the same numbers go in and come back
-        #: out. It stops being harmless once the automated adjoint has run,
-        #: because by then two things live inside those particular objects.
-        #: The pyadjoint controls refer to them by identity, and an
-        #: inversion has written its current iterate into them. A rebuild
-        #: would leave the controls pointing at objects the solve no longer
-        #: uses, and reset the iterate to the model's initial values. So
-        #: from that point on the rebuild is skipped.
+        #: out. It stops being harmless once the adjoint equation has been
+        #: set up, because the adjoint is posed with respect to those exact
+        #: objects, and an inversion has written its current iterate into
+        #: them. A rebuild would differentiate with respect to objects the
+        #: forward solve no longer uses, and reset the iterate to the
+        #: model's initial values. So from that point on it is skipped.
         self._physical_parameters_are_built = False
 
         self.u_n = None   # Current displacement field
@@ -140,93 +139,61 @@ class IsotropicWave(ElasticWave):
         if self._physical_parameters_are_built:
             return
 
-        def material_parameter(value):
-            """Normalize model-dictionary values for elastic parameters.
-
-            Parameters
-            ----------
-            value : scalar, firedrake.Constant, firedrake.Function, or UFL expression
-                Material parameter read from ``synthetic_data_dict``.
-
-            Returns
-            -------
-            firedrake.Constant, firedrake.Function, or object
-                Scalars and ``Constant`` values are converted to scalar
-                material ``Function`` objects once a mesh exists. Before mesh
-                creation, scalar values remain as ``Constant`` values so the
-                regular model initialization flow can continue.
-
-            Examples
-            --------
-            ``density=1.0`` becomes ``Constant(1.0)`` before the mesh exists,
-            and becomes a scalar material ``Function`` after the mesh has been
-            created.
-            """
-            if np.isscalar(value) or isinstance(value, Constant):
-                if self.mesh is None:
-                    return Constant(value) if np.isscalar(value) else value
-                V = create_function_space(
-                    self.mesh, self.method, self.degree, dim=1,
-                )
-                return Function(V).interpolate(value)
-            return value
-
-        def get_value(parameter, *aliases):
+        def declared(parameter, *aliases):
+            """Return the model value of ``parameter``, or ``None``."""
             for key in (parameter.value, *aliases):
                 if key in synthetic_data_dict:
-                    return material_parameter(synthetic_data_dict[key])
+                    value = synthetic_data_dict[key]
+                    return Constant(value) if np.isscalar(value) else value
             return None
 
-        self.rho = get_value(ElasticMaterialParameter.DENSITY)
-        self.lmbda = get_value(
-            ElasticMaterialParameter.LAMBDA,
-            "lame_first",
-        )
-        self.mu = get_value(
-            ElasticMaterialParameter.MU,
-            "lame_second",
-        )
-        self.c = get_value(ElasticMaterialParameter.P_WAVE_VELOCITY)
-        self.c_s = get_value(ElasticMaterialParameter.S_WAVE_VELOCITY)
+        self.rho = declared(ElasticMaterialParameter.DENSITY)
+        self.lmbda = declared(ElasticMaterialParameter.LAMBDA, "lame_first")
+        self.mu = declared(ElasticMaterialParameter.MU, "lame_second")
+        self.c = declared(ElasticMaterialParameter.P_WAVE_VELOCITY)
+        self.c_s = declared(ElasticMaterialParameter.S_WAVE_VELOCITY)
 
-        # Check if {rho, lambda, mu} is set and {c, c_s} are not
-        option_1 = bool(self.rho) and \
-            bool(self.lmbda) and \
-            bool(self.mu) and \
-            not bool(self.c) and \
-            not bool(self.c_s)
-        # Check if {rho, c, c_s} is set and {lambda, mu} are not
-        option_2 = bool(self.rho) and \
-            bool(self.c) and \
-            bool(self.c_s) and \
-            not bool(self.lmbda) and \
-            not bool(self.mu)
+        # Exactly one family must be declared, and it names the family the
+        # equation is written in. ``is not None`` rather than truthiness:
+        # every UFL object is unconditionally true, so ``bool`` would only
+        # ever be testing whether the key was present.
+        lame = (
+            self.rho is not None
+            and self.lmbda is not None
+            and self.mu is not None
+            and self.c is None
+            and self.c_s is None
+        )
+        velocity = (
+            self.rho is not None
+            and self.c is not None
+            and self.c_s is not None
+            and self.lmbda is None
+            and self.mu is None
+        )
 
-        if option_1:
-            self._physical_parameterization = ElasticMaterialParameterization.LAME
-            self.c = ((self.lmbda + 2*self.mu)/self.rho)**0.5
-            self.c_s = (self.mu/self.rho)**0.5
-        elif option_2:
-            self._physical_parameterization = ElasticMaterialParameterization.VELOCITY
-            self.mu = self.rho*self.c_s**2
-            self.lmbda = self.rho*self.c**2 - 2*self.mu
-        else:
-            raise ValueError(
-                "Inconsistent selection of isotropic elastic wave parameters:\n"
-                f"    Density        : {bool(self.rho)}\n"
-                f"    Lame first     : {bool(self.lmbda)}\n"
-                f"    Lame second    : {bool(self.mu)}\n"
-                f"    P-wave velocity: {bool(self.c)}\n"
-                f"    S-wave velocity: {bool(self.c_s)}\n"
-                "The valid options are {Density, Lame first, Lame second} "
-                "or (exclusive) {Density, P-wave velocity, S-wave velocity}",
+        if lame:
+            declared_parameterization = ElasticMaterialParameterization.LAME
+        elif velocity:
+            declared_parameterization = (
+                ElasticMaterialParameterization.VELOCITY
             )
-        add = self._physical_parameters.add
-        add(ElasticMaterialParameter.DENSITY, self.rho)
-        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
-        add(ElasticMaterialParameter.MU, self.mu)
-        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
-        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
+        else:
+            families = " or (exclusive) ".join(
+                _format_physical_parameters(family)
+                for family in PHYSICAL_PARAMETERIZATION.values()
+            )
+            raise ValueError(
+                "Inconsistent selection of isotropic elastic wave "
+                "parameters:\n"
+                f"    Density        : {self.rho is not None}\n"
+                f"    Lame first     : {self.lmbda is not None}\n"
+                f"    Lame second    : {self.mu is not None}\n"
+                f"    P-wave velocity: {self.c is not None}\n"
+                f"    S-wave velocity: {self.c_s is not None}\n"
+                f"The valid options are {families}",
+            )
+        self._set_physical_parameterization(declared_parameterization)
 
     def _set_physical_parameterization(
         self, parameterization: ElasticMaterialParameterization,
@@ -239,10 +206,11 @@ class IsotropicWave(ElasticWave):
         and to the assembled variational forms.
 
         Once a family has been materialized the fields belong to this object
-        rather than to the model dictionary: they may be registered as
-        pyadjoint controls, and rebuilding them from the dictionary would
-        both discard the current values and orphan those controls, which is
-        why this sets ``_physical_parameters_are_built``.
+        rather than to the model dictionary: the adjoint equation may already
+        be posed with respect to them, and rebuilding them from the
+        dictionary would both discard the current values and leave that
+        adjoint differentiating unused fields, which is why this sets
+        ``_physical_parameters_are_built``.
 
         Parameters
         ----------
@@ -259,33 +227,33 @@ class IsotropicWave(ElasticWave):
             If the mesh has not been created, or the family is not one this
             solver supports.
         """
-        if self.mesh is None:
-            raise ValueError(
-                "Mesh must be set before creating elastic physical "
-                "parameters.",
-            )
-        space = create_function_space(
+        space = None if self.mesh is None else create_function_space(
             self.mesh, self.method, self.degree, dim=1,
         )
 
-        def as_field(value, parameter):
-            """Return ``value`` as an independent field of ``parameter``."""
-            if isinstance(value, Function):
+        def as_function(value, parameter):
+            """Return ``value`` as the independent field of ``parameter``.
+
+            Before a mesh exists there is no space to build a ``Function``
+            in, so the value is left as the scalar or ``Constant`` it came
+            in as and the equation is still written in this family.
+            """
+            if space is None or isinstance(value, Function):
                 return value
             return Function(space, name=parameter.value).interpolate(value)
 
         if parameterization is ElasticMaterialParameterization.LAME:
-            self.rho = as_field(self.rho, ElasticMaterialParameter.DENSITY)
-            self.lmbda = as_field(self.lmbda, ElasticMaterialParameter.LAMBDA)
-            self.mu = as_field(self.mu, ElasticMaterialParameter.MU)
+            self.rho = as_function(self.rho, ElasticMaterialParameter.DENSITY)
+            self.lmbda = as_function(self.lmbda, ElasticMaterialParameter.LAMBDA)
+            self.mu = as_function(self.mu, ElasticMaterialParameter.MU)
             self.c = ((self.lmbda + 2*self.mu)/self.rho)**0.5
             self.c_s = (self.mu/self.rho)**0.5
         elif parameterization is ElasticMaterialParameterization.VELOCITY:
-            self.rho = as_field(self.rho, ElasticMaterialParameter.DENSITY)
-            self.c = as_field(
+            self.rho = as_function(self.rho, ElasticMaterialParameter.DENSITY)
+            self.c = as_function(
                 self.c, ElasticMaterialParameter.P_WAVE_VELOCITY,
             )
-            self.c_s = as_field(
+            self.c_s = as_function(
                 self.c_s, ElasticMaterialParameter.S_WAVE_VELOCITY,
             )
             self.mu = self.rho*self.c_s**2
@@ -297,7 +265,6 @@ class IsotropicWave(ElasticWave):
             )
 
         self._physical_parameterization = parameterization
-        self._physical_parameters_are_built = True
         add = self._physical_parameters.add
         add(ElasticMaterialParameter.DENSITY, self.rho)
         add(ElasticMaterialParameter.LAMBDA, self.lmbda)
@@ -378,7 +345,14 @@ class IsotropicWave(ElasticWave):
                 f"got {_format_physical_parameters(selected_names)}.",
             )
         target = current if current in candidates else candidates[0]
+        if self.mesh is None:
+            raise ValueError(
+                "Mesh must be set before selecting elastic physical "
+                "parameters: a control has to be a field.",
+            )
         self._set_physical_parameterization(target)
+        # From here on the fields are this solver's own; see the attribute.
+        self._physical_parameters_are_built = True
 
         selected = PhysicalParameters()
         for parameter in PHYSICAL_PARAMETERIZATION[target]:
@@ -401,7 +375,8 @@ class IsotropicWave(ElasticWave):
             Accepted for compatibility; the recorded functional owns the
             elastic misfit.
         forward_solution : firedrake.Function, optional
-            Accepted for compatibility; the automated adjoint replays its tape.
+            Accepted for compatibility; the automated adjoint recovers the
+            forward wavefield on its own.
         adjoint_type : AdjointType, optional
             Must be :attr:`AdjointType.AUTOMATED_ADJOINT`.
         riesz_map : RieszMapType, optional

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -100,12 +100,15 @@ class IsotropicWave(ElasticWave):
         P- and S-wave velocities. The missing dependent parameters are
         computed from the provided set.
 
-        Every forward solve calls this method again, so it only reads the
-        model once: the parameters it built the first time are the objects
-        the assembled forms, the adjoint and any inversion refer to, and
-        rebuilding them would replace those objects and reset an inversion's
-        current iterate to the model's initial values. Replacing the model
-        clears the parameters, which is what allows them to be built again.
+        This runs more than once: :meth:`enable_automated_adjoint` and
+        :meth:`initialize_physical_parameters` both call it, and so does the
+        forward solve itself for absorbing-boundary settings that rebuild
+        the material properties. It reads the model only on the first of
+        those. The parameters built then are the objects the assembled
+        forms, the adjoint and any inversion refer to, so rebuilding them
+        would replace those objects and reset an inversion's current iterate
+        to the model's initial values. Replacing the model clears the
+        parameters, which is what allows them to be built again.
 
         Parameters
         ----------

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -2,13 +2,16 @@ import numpy as np
 
 from firedrake import (assemble, Constant, curl, DirichletBC, div, Function,
                        project)
+from pyadjoint import AdjFloat, Tape
 
 from .elastic_wave import ElasticWave
 from .forms import (isotropic_elastic_without_pml,
                     isotropic_elastic_with_pml)
 from .functionals import mechanical_energy_form
-from ...utils.typing import (ElasticMaterialParameter, ElasticMaterialParameterization,
-                             AbsorbingBCsType, override)
+from ...utils.physical_parameters import PhysicalParameters
+from ...utils.typing import (AdjointType, ElasticMaterialParameter,
+                             ElasticMaterialParameterization, AbsorbingBCsType,
+                             RieszMapType, override)
 from ...domains.space import create_function_space
 
 
@@ -23,6 +26,14 @@ PHYSICAL_PARAMETERIZATION = {
         ElasticMaterialParameter.P_WAVE_VELOCITY,
         ElasticMaterialParameter.S_WAVE_VELOCITY,
     ),
+}
+
+ATTRIBUTE_BY_PARAMETER = {
+    ElasticMaterialParameter.DENSITY: "rho",
+    ElasticMaterialParameter.LAMBDA: "lmbda",
+    ElasticMaterialParameter.MU: "mu",
+    ElasticMaterialParameter.P_WAVE_VELOCITY: "c",
+    ElasticMaterialParameter.S_WAVE_VELOCITY: "c_s",
 }
 
 
@@ -198,12 +209,304 @@ class IsotropicWave(ElasticWave):
                 "The valid options are {Density, Lame first, Lame second} "
                 "or (exclusive) {Density, P-wave velocity, S-wave velocity}",
             )
-        add = self._physical_parameters.add
-        add(ElasticMaterialParameter.DENSITY, self.rho)
-        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
-        add(ElasticMaterialParameter.MU, self.mu)
-        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
-        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
+        self._register_physical_parameters()
+
+    def get_control_parameter_function_space(self) -> object:
+        """Return the scalar space used for material controls.
+
+        Returns
+        -------
+        firedrake.FunctionSpace
+            Scalar finite-element space on the elastic mesh.
+
+        Raises
+        ------
+        ValueError
+            If the mesh has not been created.
+        """
+        if self.mesh is None:
+            raise ValueError(
+                "Mesh must be set before creating elastic control fields.",
+            )
+        space = self._material_parameter_function_space
+        if space is None or space.mesh() is not self.mesh:
+            space = create_function_space(
+                self.mesh, self.method, self.degree, dim=1,
+            )
+            self._material_parameter_function_space = space
+        return space
+
+    def _get_material_parameter(
+        self, parameter: ElasticMaterialParameter,
+    ) -> object:
+        """Return one elastic physical field or expression.
+
+        Parameters
+        ----------
+        parameter : ElasticMaterialParameter
+            Physical parameter to retrieve.
+
+        Returns
+        -------
+        object
+            Firedrake field or dependent UFL expression.
+        """
+        return getattr(self, ATTRIBUTE_BY_PARAMETER[parameter])
+
+    def _set_material_parameter(
+        self, parameter: ElasticMaterialParameter, value: object,
+    ) -> None:
+        """Assign one elastic physical field or expression.
+
+        Parameters
+        ----------
+        parameter : ElasticMaterialParameter
+            Physical parameter to assign.
+        value : object
+            Firedrake field or dependent UFL expression.
+
+        Returns
+        -------
+        None
+        """
+        setattr(self, ATTRIBUTE_BY_PARAMETER[parameter], value)
+
+    def _derive_complementary_parameters(
+        self, parameterization: ElasticMaterialParameterization,
+    ) -> None:
+        """Express dependent parameters using one independent family.
+
+        Parameters
+        ----------
+        parameterization : ElasticMaterialParameterization
+            Family whose three parameters are independent fields.
+
+        Returns
+        -------
+        None
+        """
+        if parameterization is ElasticMaterialParameterization.LAME:
+            self.c = ((self.lmbda + 2*self.mu)/self.rho)**0.5
+            self.c_s = (self.mu/self.rho)**0.5
+        else:
+            self.mu = self.rho*self.c_s**2
+            self.lmbda = self.rho*self.c**2 - 2*self.mu
+
+    def _register_physical_parameters(self) -> None:
+        """Register the current elastic fields and expressions.
+
+        Returns
+        -------
+        None
+        """
+        for parameter in ElasticMaterialParameter:
+            self._physical_parameters.add(
+                parameter, self._get_material_parameter(parameter),
+            )
+
+    def _record_parameterization(
+        self, parameterization: ElasticMaterialParameterization,
+    ) -> None:
+        """Persist independent fields for the next forward initialization.
+
+        ``forward_solve`` reads the material dictionary again. Storing the
+        actual independent ``Function`` objects preserves their identity, so
+        the fields in the variational form remain the controls registered on
+        the pyadjoint tape.
+
+        Parameters
+        ----------
+        parameterization : ElasticMaterialParameterization
+            Independent family to write to ``synthetic_data``.
+
+        Returns
+        -------
+        None
+        """
+        synthetic_data = self.input_dictionary["synthetic_data"]
+        for parameter in ElasticMaterialParameter:
+            synthetic_data.pop(parameter.value, None)
+        synthetic_data.pop("lame_first", None)
+        synthetic_data.pop("lame_second", None)
+        for parameter in PHYSICAL_PARAMETERIZATION[parameterization]:
+            synthetic_data[parameter.value] = self._get_material_parameter(
+                parameter,
+            )
+
+    def _set_physical_parameterization(
+        self, parameterization: ElasticMaterialParameterization,
+    ) -> None:
+        """Materialize one independent elastic parameter family.
+
+        This change of variables occurs before tape recording. The target
+        family becomes three scalar ``Function`` objects and the complementary
+        family remains algebraically linked through UFL expressions.
+
+        Parameters
+        ----------
+        parameterization : ElasticMaterialParameterization
+            Independent family required by the selected controls.
+
+        Returns
+        -------
+        None
+        """
+        if parameterization is self._physical_parameterization:
+            # Model dictionaries often contain scalars. Replace them with the
+            # initialized fields so forward_solve() does not create new
+            # Functions and detach the registered pyadjoint controls.
+            self._record_parameterization(parameterization)
+            return
+
+        space = self.get_control_parameter_function_space()
+        for parameter in PHYSICAL_PARAMETERIZATION[parameterization]:
+            value = self._get_material_parameter(parameter)
+            if isinstance(value, Function):
+                field = value
+            else:
+                field = Function(space, name=parameter.value).interpolate(value)
+            self._set_material_parameter(parameter, field)
+
+        self._physical_parameterization = parameterization
+        self._derive_complementary_parameters(parameterization)
+        self._register_physical_parameters()
+        self._record_parameterization(parameterization)
+
+    @override
+    def _select_control_parameters(
+        self, parameters: object = None,
+    ) -> PhysicalParameters:
+        """Resolve an independent elastic control subset.
+
+        Parameters
+        ----------
+        parameters : ElasticMaterialParameter or iterable, optional
+            Non-empty subset of the Lame or velocity parameterization. ``None``
+            selects all three parameters of the current parameterization.
+
+        Returns
+        -------
+        PhysicalParameters
+            Selected enum names mapped to the fields used by the equation.
+
+        Raises
+        ------
+        TypeError
+            If a selection contains anything other than
+            :class:`ElasticMaterialParameter` values.
+        ValueError
+            If the selection is empty, duplicated, or mixes parameterizations.
+        """
+        current = self._physical_parameterization
+        if parameters is None:
+            selected_names = list(PHYSICAL_PARAMETERIZATION[current])
+        elif isinstance(parameters, ElasticMaterialParameter):
+            selected_names = [parameters]
+        else:
+            selected_names = list(parameters)
+
+        if not selected_names:
+            raise ValueError("At least one elastic control parameter is required.")
+        if not all(
+            isinstance(name, ElasticMaterialParameter)
+            for name in selected_names
+        ):
+            raise TypeError(
+                "Elastic controls must be ElasticMaterialParameter enum "
+                "members.",
+            )
+        if len(set(selected_names)) != len(selected_names):
+            raise ValueError("Elastic control parameters must be unique.")
+
+        selected = set(selected_names)
+        candidates = [
+            parameterization
+            for parameterization, family in PHYSICAL_PARAMETERIZATION.items()
+            if selected <= set(family)
+        ]
+        if not candidates:
+            raise ValueError(
+                "Elastic controls must be a subset of either "
+                "{density, lambda, mu} or "
+                "{density, p_wave_velocity, s_wave_velocity}; got "
+                f"{_format_physical_parameters(selected_names)}.",
+            )
+        target = current if current in candidates else candidates[0]
+        self._set_physical_parameterization(target)
+
+        controls = PhysicalParameters()
+        for parameter in PHYSICAL_PARAMETERIZATION[target]:
+            if parameter in selected:
+                controls.add(parameter, self._get_material_parameter(parameter))
+        return controls
+
+    @override
+    def gradient_solve(
+        self,
+        misfit=None,
+        forward_solution=None,
+        adjoint_type=AdjointType.AUTOMATED_ADJOINT,
+        riesz_map=RieszMapType.L2,
+    ) -> PhysicalParameters:
+        """Compute automated-adjoint elastic material derivatives.
+
+        Parameters
+        ----------
+        misfit : array_like, optional
+            Accepted for compatibility; the recorded functional owns the
+            elastic misfit.
+        forward_solution : firedrake.Function, optional
+            Accepted for compatibility; the automated adjoint replays its tape.
+        adjoint_type : AdjointType, optional
+            Must be :attr:`AdjointType.AUTOMATED_ADJOINT`.
+        riesz_map : RieszMapType, optional
+            ``L2`` returns primal gradients and ``l2`` raw derivatives.
+
+        Returns
+        -------
+        PhysicalParameters
+            Derivatives keyed by the selected elastic parameter enums.
+
+        Raises
+        ------
+        NotImplementedError
+            If a hand-implemented adjoint or unsupported Riesz map is requested.
+        ValueError
+            If no valid annotated functional is available.
+        """
+        if adjoint_type is not AdjointType.AUTOMATED_ADJOINT:
+            raise NotImplementedError(
+                "Elastic gradients only support the automated adjoint.",
+            )
+        if not isinstance(self.functional_value, AdjFloat):
+            raise ValueError(
+                "Functional value must be an AdjFloat for automated adjoint "
+                "gradient computation.",
+            )
+        if self.automated_adjoint is None:
+            raise ValueError(
+                "Enable the automated adjoint before the elastic forward solve.",
+            )
+        if (
+            self.automated_adjoint.reduced_functional is None
+            and isinstance(self.automated_adjoint._tape, Tape)
+        ):
+            self.automated_adjoint.create_reduced_functional(
+                self.functional_value,
+            )
+
+        if riesz_map is RieszMapType.L2:
+            derivatives = self.automated_adjoint.compute_gradient()
+        elif riesz_map is RieszMapType.l2:
+            derivatives = self.automated_adjoint.compute_derivative()
+        else:
+            raise NotImplementedError(
+                f"Riesz map {riesz_map} not implemented for automated adjoint.",
+            )
+        return PhysicalParameters(zip(
+            self.automated_adjoint.control_parameter_names,
+            derivatives,
+        ))
 
     @override
     def initialize_model_parameters_from_file(self, synthetic_data_dict):

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -8,54 +8,12 @@ from .elastic_wave import ElasticWave
 from .forms import (isotropic_elastic_without_pml,
                     isotropic_elastic_with_pml)
 from .functionals import mechanical_energy_form
-from ...utils.physical_parameters import PhysicalParameters
+from ...utils.physical_parameters import (ELASTIC_PARAMETERIZATIONS,
+                                          PhysicalParameters)
 from ...utils.typing import (AdjointType, ElasticMaterialParameter,
                              ElasticMaterialParameterization, AbsorbingBCsType,
-                             RieszMapType, override)
+                             RieszMapType)
 from ...domains.space import create_function_space
-
-
-PHYSICAL_PARAMETERIZATION = {
-    ElasticMaterialParameterization.LAME: (
-        ElasticMaterialParameter.DENSITY,
-        ElasticMaterialParameter.LAMBDA,
-        ElasticMaterialParameter.MU,
-    ),
-    ElasticMaterialParameterization.VELOCITY: (
-        ElasticMaterialParameter.DENSITY,
-        ElasticMaterialParameter.P_WAVE_VELOCITY,
-        ElasticMaterialParameter.S_WAVE_VELOCITY,
-    ),
-}
-
-ATTRIBUTE_BY_PARAMETER = {
-    ElasticMaterialParameter.DENSITY: "rho",
-    ElasticMaterialParameter.LAMBDA: "lmbda",
-    ElasticMaterialParameter.MU: "mu",
-    ElasticMaterialParameter.P_WAVE_VELOCITY: "c",
-    ElasticMaterialParameter.S_WAVE_VELOCITY: "c_s",
-}
-
-
-def _format_physical_parameters(parameters):
-    """Format material-parameter enum values for error messages.
-
-    Parameters
-    ----------
-    parameters : iterable of ElasticMaterialParameter
-        Material-parameter enum values to display.
-
-    Returns
-    -------
-    str
-        Human-readable set-like representation using public parameter names.
-
-    Examples
-    --------
-    ``(ElasticMaterialParameter.DENSITY, ElasticMaterialParameter.MU)``
-    becomes ``"{density, mu}"``.
-    """
-    return "{" + ", ".join(parameter.value for parameter in parameters) + "}"
 
 
 class IsotropicWave(ElasticWave):
@@ -102,15 +60,14 @@ class IsotropicWave(ElasticWave):
         self.field_logger.add_functional("mechanical_energy",
                                          lambda: assemble(self.mechanical_energy))
 
-    @override
     def initialize_model_parameters_from_object(self, synthetic_data_dict: dict):
         """Initialize isotropic elastic material parameters from a dictionary.
 
         The dictionary must define exactly one supported material
         parameterization: either density with Lame parameters, or density with
         P- and S-wave velocities. The missing dependent parameters are computed
-        from the provided set, and the active control parameterization is stored
-        for FWI.
+        from the provided set, and the active physical parameterization is
+        stored.
 
         Parameters
         ----------
@@ -126,7 +83,7 @@ class IsotropicWave(ElasticWave):
         -------
         None
             The method assigns ``rho``, ``lmbda``, ``mu``, ``c``, ``c_s``, and
-            the active control parameterization on ``self``.
+            the active physical parameterization on ``self``.
         """
         def material_parameter(value):
             """Normalize model-dictionary values for elastic parameters.
@@ -209,10 +166,15 @@ class IsotropicWave(ElasticWave):
                 "The valid options are {Density, Lame first, Lame second} "
                 "or (exclusive) {Density, P-wave velocity, S-wave velocity}",
             )
-        self._register_physical_parameters()
+        add = self._physical_parameters.add
+        add(ElasticMaterialParameter.DENSITY, self.rho)
+        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
+        add(ElasticMaterialParameter.MU, self.mu)
+        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
+        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
 
-    def get_control_parameter_function_space(self) -> object:
-        """Return the scalar space used for material controls.
+    def _material_parameter_space(self) -> object:
+        """Return the scalar space used for material parameters.
 
         Returns
         -------
@@ -226,7 +188,7 @@ class IsotropicWave(ElasticWave):
         """
         if self.mesh is None:
             raise ValueError(
-                "Mesh must be set before creating elastic control fields.",
+                "Mesh must be set before creating elastic material fields.",
             )
         space = self._material_parameter_function_space
         if space is None or space.mesh() is not self.mesh:
@@ -251,7 +213,17 @@ class IsotropicWave(ElasticWave):
         object
             Firedrake field or dependent UFL expression.
         """
-        return getattr(self, ATTRIBUTE_BY_PARAMETER[parameter])
+        if parameter is ElasticMaterialParameter.DENSITY:
+            return self.rho
+        if parameter is ElasticMaterialParameter.LAMBDA:
+            return self.lmbda
+        if parameter is ElasticMaterialParameter.MU:
+            return self.mu
+        if parameter is ElasticMaterialParameter.P_WAVE_VELOCITY:
+            return self.c
+        if parameter is ElasticMaterialParameter.S_WAVE_VELOCITY:
+            return self.c_s
+        raise ValueError(f"Unsupported elastic material parameter: {parameter}.")
 
     def _set_material_parameter(
         self, parameter: ElasticMaterialParameter, value: object,
@@ -269,7 +241,20 @@ class IsotropicWave(ElasticWave):
         -------
         None
         """
-        setattr(self, ATTRIBUTE_BY_PARAMETER[parameter], value)
+        if parameter is ElasticMaterialParameter.DENSITY:
+            self.rho = value
+        elif parameter is ElasticMaterialParameter.LAMBDA:
+            self.lmbda = value
+        elif parameter is ElasticMaterialParameter.MU:
+            self.mu = value
+        elif parameter is ElasticMaterialParameter.P_WAVE_VELOCITY:
+            self.c = value
+        elif parameter is ElasticMaterialParameter.S_WAVE_VELOCITY:
+            self.c_s = value
+        else:
+            raise ValueError(
+                f"Unsupported elastic material parameter: {parameter}.",
+            )
 
     def _derive_complementary_parameters(
         self, parameterization: ElasticMaterialParameterization,
@@ -310,9 +295,8 @@ class IsotropicWave(ElasticWave):
         """Persist independent fields for the next forward initialization.
 
         ``forward_solve`` reads the material dictionary again. Storing the
-        actual independent ``Function`` objects preserves their identity, so
-        the fields in the variational form remain the controls registered on
-        the pyadjoint tape.
+        actual independent ``Function`` objects preserves their identity across
+        model initialization.
 
         Parameters
         ----------
@@ -328,7 +312,7 @@ class IsotropicWave(ElasticWave):
             synthetic_data.pop(parameter.value, None)
         synthetic_data.pop("lame_first", None)
         synthetic_data.pop("lame_second", None)
-        for parameter in PHYSICAL_PARAMETERIZATION[parameterization]:
+        for parameter in ELASTIC_PARAMETERIZATIONS[parameterization]:
             synthetic_data[parameter.value] = self._get_material_parameter(
                 parameter,
             )
@@ -345,7 +329,7 @@ class IsotropicWave(ElasticWave):
         Parameters
         ----------
         parameterization : ElasticMaterialParameterization
-            Independent family required by the selected controls.
+            Independent physical parameter family to materialize.
 
         Returns
         -------
@@ -354,12 +338,12 @@ class IsotropicWave(ElasticWave):
         if parameterization is self._physical_parameterization:
             # Model dictionaries often contain scalars. Replace them with the
             # initialized fields so forward_solve() does not create new
-            # Functions and detach the registered pyadjoint controls.
+            # Functions and invalidate external references to these fields.
             self._record_parameterization(parameterization)
             return
 
-        space = self.get_control_parameter_function_space()
-        for parameter in PHYSICAL_PARAMETERIZATION[parameterization]:
+        space = self._material_parameter_space()
+        for parameter in ELASTIC_PARAMETERIZATIONS[parameterization]:
             value = self._get_material_parameter(parameter)
             if isinstance(value, Function):
                 field = value
@@ -372,75 +356,6 @@ class IsotropicWave(ElasticWave):
         self._register_physical_parameters()
         self._record_parameterization(parameterization)
 
-    @override
-    def _select_control_parameters(
-        self, parameters: object = None,
-    ) -> PhysicalParameters:
-        """Resolve an independent elastic control subset.
-
-        Parameters
-        ----------
-        parameters : ElasticMaterialParameter or iterable, optional
-            Non-empty subset of the Lame or velocity parameterization. ``None``
-            selects all three parameters of the current parameterization.
-
-        Returns
-        -------
-        PhysicalParameters
-            Selected enum names mapped to the fields used by the equation.
-
-        Raises
-        ------
-        TypeError
-            If a selection contains anything other than
-            :class:`ElasticMaterialParameter` values.
-        ValueError
-            If the selection is empty, duplicated, or mixes parameterizations.
-        """
-        current = self._physical_parameterization
-        if parameters is None:
-            selected_names = list(PHYSICAL_PARAMETERIZATION[current])
-        elif isinstance(parameters, ElasticMaterialParameter):
-            selected_names = [parameters]
-        else:
-            selected_names = list(parameters)
-
-        if not selected_names:
-            raise ValueError("At least one elastic control parameter is required.")
-        if not all(
-            isinstance(name, ElasticMaterialParameter)
-            for name in selected_names
-        ):
-            raise TypeError(
-                "Elastic controls must be ElasticMaterialParameter enum "
-                "members.",
-            )
-        if len(set(selected_names)) != len(selected_names):
-            raise ValueError("Elastic control parameters must be unique.")
-
-        selected = set(selected_names)
-        candidates = [
-            parameterization
-            for parameterization, family in PHYSICAL_PARAMETERIZATION.items()
-            if selected <= set(family)
-        ]
-        if not candidates:
-            raise ValueError(
-                "Elastic controls must be a subset of either "
-                "{density, lambda, mu} or "
-                "{density, p_wave_velocity, s_wave_velocity}; got "
-                f"{_format_physical_parameters(selected_names)}.",
-            )
-        target = current if current in candidates else candidates[0]
-        self._set_physical_parameterization(target)
-
-        controls = PhysicalParameters()
-        for parameter in PHYSICAL_PARAMETERIZATION[target]:
-            if parameter in selected:
-                controls.add(parameter, self._get_material_parameter(parameter))
-        return controls
-
-    @override
     def gradient_solve(
         self,
         misfit=None,
@@ -503,47 +418,35 @@ class IsotropicWave(ElasticWave):
             raise NotImplementedError(
                 f"Riesz map {riesz_map} not implemented for automated adjoint.",
             )
-        return PhysicalParameters(zip(
-            self.automated_adjoint.control_parameter_names,
-            derivatives,
-        ))
+        return self.automated_adjoint.label_derivatives(derivatives)
 
-    @override
     def initialize_model_parameters_from_file(self, synthetic_data_dict):
         raise NotImplementedError
 
-    @override
     def _create_function_space(self):
         return create_function_space(self.mesh, self.method, self.degree,
                                      dim=self.dimension)
 
-    @override
     def _set_vstate(self, vstate):
         self.u_n.assign(vstate)
 
-    @override
     def _get_vstate(self):
         return self.u_n
 
-    @override
     def _set_prev_vstate(self, vstate):
         if self.u_nm2 is not None:
             self.u_nm2.assign(self.u_nm1)
         self.u_nm1.assign(vstate)
 
-    @override
     def _get_prev_vstate(self):
         return self.u_nm1
 
-    @override
     def _set_next_vstate(self, vstate):
         self.u_np1.assign(vstate)
 
-    @override
     def _get_next_vstate(self):
         return self.u_np1
 
-    @override
     def get_forward_solution_receivers(self):
         if self.abc_type == AbsorbingBCsType.PML:
             raise NotImplementedError
@@ -551,15 +454,12 @@ class IsotropicWave(ElasticWave):
             data_with_halos = self.u_n.dat.data_ro_with_halos[:]
         return self.receivers.interpolate(data_with_halos)
 
-    @override
     def get_function(self):
         return self.u_n
 
-    @override
     def get_function_name(self):
         return "Displacement"
 
-    @override
     def matrix_building(self):
         self.current_time = 0.0
 
@@ -590,7 +490,6 @@ class IsotropicWave(ElasticWave):
         elif self.abc_type == AbsorbingBCsType.PML:
             isotropic_elastic_with_pml(self)
 
-    @override
     def rhs_no_pml(self):
         if self.abc_type == AbsorbingBCsType.PML:
             raise NotImplementedError

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -8,8 +8,7 @@ from .elastic_wave import ElasticWave
 from .forms import (isotropic_elastic_without_pml,
                     isotropic_elastic_with_pml)
 from .functionals import mechanical_energy_form
-from ...utils.physical_parameters import (ELASTIC_PARAMETERIZATIONS,
-                                          PhysicalParameters)
+from ...utils.physical_parameters import PhysicalParameters
 from ...utils.typing import (AdjointType, ElasticMaterialParameter,
                              ElasticMaterialParameterization, AbsorbingBCsType,
                              RieszMapType)
@@ -198,97 +197,6 @@ class IsotropicWave(ElasticWave):
             self._material_parameter_function_space = space
         return space
 
-    def _get_material_parameter(
-        self, parameter: ElasticMaterialParameter,
-    ) -> object:
-        """Return one elastic physical field or expression.
-
-        Parameters
-        ----------
-        parameter : ElasticMaterialParameter
-            Physical parameter to retrieve.
-
-        Returns
-        -------
-        object
-            Firedrake field or dependent UFL expression.
-        """
-        if parameter is ElasticMaterialParameter.DENSITY:
-            return self.rho
-        if parameter is ElasticMaterialParameter.LAMBDA:
-            return self.lmbda
-        if parameter is ElasticMaterialParameter.MU:
-            return self.mu
-        if parameter is ElasticMaterialParameter.P_WAVE_VELOCITY:
-            return self.c
-        if parameter is ElasticMaterialParameter.S_WAVE_VELOCITY:
-            return self.c_s
-        raise ValueError(f"Unsupported elastic material parameter: {parameter}.")
-
-    def _set_material_parameter(
-        self, parameter: ElasticMaterialParameter, value: object,
-    ) -> None:
-        """Assign one elastic physical field or expression.
-
-        Parameters
-        ----------
-        parameter : ElasticMaterialParameter
-            Physical parameter to assign.
-        value : object
-            Firedrake field or dependent UFL expression.
-
-        Returns
-        -------
-        None
-        """
-        if parameter is ElasticMaterialParameter.DENSITY:
-            self.rho = value
-        elif parameter is ElasticMaterialParameter.LAMBDA:
-            self.lmbda = value
-        elif parameter is ElasticMaterialParameter.MU:
-            self.mu = value
-        elif parameter is ElasticMaterialParameter.P_WAVE_VELOCITY:
-            self.c = value
-        elif parameter is ElasticMaterialParameter.S_WAVE_VELOCITY:
-            self.c_s = value
-        else:
-            raise ValueError(
-                f"Unsupported elastic material parameter: {parameter}.",
-            )
-
-    def _derive_complementary_parameters(
-        self, parameterization: ElasticMaterialParameterization,
-    ) -> None:
-        """Express dependent parameters using one independent family.
-
-        Parameters
-        ----------
-        parameterization : ElasticMaterialParameterization
-            Family whose three parameters are independent fields.
-
-        Returns
-        -------
-        None
-        """
-        if parameterization is ElasticMaterialParameterization.LAME:
-            self.c = ((self.lmbda + 2*self.mu)/self.rho)**0.5
-            self.c_s = (self.mu/self.rho)**0.5
-        else:
-            self.mu = self.rho*self.c_s**2
-            self.lmbda = self.rho*self.c**2 - 2*self.mu
-
-    def _register_physical_parameters(self) -> None:
-        """Register the current elastic fields and expressions.
-
-        Returns
-        -------
-        None
-        """
-        for parameter in ElasticMaterialParameter:
-            self._physical_parameters.add(
-                parameter, self._get_material_parameter(parameter),
-            )
-
     def _record_parameterization(
         self, parameterization: ElasticMaterialParameterization,
     ) -> None:
@@ -312,9 +220,22 @@ class IsotropicWave(ElasticWave):
             synthetic_data.pop(parameter.value, None)
         synthetic_data.pop("lame_first", None)
         synthetic_data.pop("lame_second", None)
-        for parameter in ELASTIC_PARAMETERIZATIONS[parameterization]:
-            synthetic_data[parameter.value] = self._get_material_parameter(
-                parameter,
+        if parameterization is ElasticMaterialParameterization.LAME:
+            synthetic_data[ElasticMaterialParameter.DENSITY.value] = self.rho
+            synthetic_data[ElasticMaterialParameter.LAMBDA.value] = self.lmbda
+            synthetic_data[ElasticMaterialParameter.MU.value] = self.mu
+        elif parameterization is ElasticMaterialParameterization.VELOCITY:
+            synthetic_data[ElasticMaterialParameter.DENSITY.value] = self.rho
+            synthetic_data[
+                ElasticMaterialParameter.P_WAVE_VELOCITY.value
+            ] = self.c
+            synthetic_data[
+                ElasticMaterialParameter.S_WAVE_VELOCITY.value
+            ] = self.c_s
+        else:
+            raise ValueError(
+                "Unsupported elastic material parameterization: "
+                f"{parameterization}.",
             )
 
     def _set_physical_parameterization(
@@ -343,17 +264,51 @@ class IsotropicWave(ElasticWave):
             return
 
         space = self._material_parameter_space()
-        for parameter in ELASTIC_PARAMETERIZATIONS[parameterization]:
-            value = self._get_material_parameter(parameter)
-            if isinstance(value, Function):
-                field = value
-            else:
-                field = Function(space, name=parameter.value).interpolate(value)
-            self._set_material_parameter(parameter, field)
+        if parameterization is ElasticMaterialParameterization.LAME:
+            if not isinstance(self.rho, Function):
+                self.rho = Function(
+                    space, name=ElasticMaterialParameter.DENSITY.value,
+                ).interpolate(self.rho)
+            if not isinstance(self.lmbda, Function):
+                self.lmbda = Function(
+                    space, name=ElasticMaterialParameter.LAMBDA.value,
+                ).interpolate(self.lmbda)
+            if not isinstance(self.mu, Function):
+                self.mu = Function(
+                    space, name=ElasticMaterialParameter.MU.value,
+                ).interpolate(self.mu)
+            self.c = ((self.lmbda + 2*self.mu)/self.rho)**0.5
+            self.c_s = (self.mu/self.rho)**0.5
+        elif parameterization is ElasticMaterialParameterization.VELOCITY:
+            if not isinstance(self.rho, Function):
+                self.rho = Function(
+                    space, name=ElasticMaterialParameter.DENSITY.value,
+                ).interpolate(self.rho)
+            if not isinstance(self.c, Function):
+                self.c = Function(
+                    space,
+                    name=ElasticMaterialParameter.P_WAVE_VELOCITY.value,
+                ).interpolate(self.c)
+            if not isinstance(self.c_s, Function):
+                self.c_s = Function(
+                    space,
+                    name=ElasticMaterialParameter.S_WAVE_VELOCITY.value,
+                ).interpolate(self.c_s)
+            self.mu = self.rho*self.c_s**2
+            self.lmbda = self.rho*self.c**2 - 2*self.mu
+        else:
+            raise ValueError(
+                "Unsupported elastic material parameterization: "
+                f"{parameterization}.",
+            )
 
         self._physical_parameterization = parameterization
-        self._derive_complementary_parameters(parameterization)
-        self._register_physical_parameters()
+        add = self._physical_parameters.add
+        add(ElasticMaterialParameter.DENSITY, self.rho)
+        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
+        add(ElasticMaterialParameter.MU, self.mu)
+        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
+        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
         self._record_parameterization(parameterization)
 
     def gradient_solve(

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -15,6 +15,41 @@ from ...utils.typing import (AdjointType, ElasticMaterialParameter,
 from ...domains.space import create_function_space
 
 
+PHYSICAL_PARAMETERIZATION = {
+    ElasticMaterialParameterization.LAME: (
+        ElasticMaterialParameter.DENSITY,
+        ElasticMaterialParameter.LAMBDA,
+        ElasticMaterialParameter.MU,
+    ),
+    ElasticMaterialParameterization.VELOCITY: (
+        ElasticMaterialParameter.DENSITY,
+        ElasticMaterialParameter.P_WAVE_VELOCITY,
+        ElasticMaterialParameter.S_WAVE_VELOCITY,
+    ),
+}
+
+
+def _format_physical_parameters(parameters):
+    """Format material-parameter enum values for error messages.
+
+    Parameters
+    ----------
+    parameters : iterable of ElasticMaterialParameter
+        Material-parameter enum values to display.
+
+    Returns
+    -------
+    str
+        Human-readable set-like representation using public parameter names.
+
+    Examples
+    --------
+    ``(ElasticMaterialParameter.DENSITY, ElasticMaterialParameter.MU)``
+    becomes ``"{density, mu}"``.
+    """
+    return "{" + ", ".join(parameter.value for parameter in parameters) + "}"
+
+
 class IsotropicWave(ElasticWave):
     '''Isotropic elastic wave propagator'''
 
@@ -30,6 +65,9 @@ class IsotropicWave(ElasticWave):
         self.mu = None    # Second Lame parameter
         self.c_s = None   # Secondary wave velocity
         self._physical_parameterization = None
+        #: Family whose independent fields already exist as ``Function``
+        #: objects owned by this solver rather than by the model dictionary.
+        self._materialized_parameterization = None
         self._material_parameter_function_space = None
 
         self.u_n = None   # Current displacement field
@@ -68,6 +106,13 @@ class IsotropicWave(ElasticWave):
         from the provided set, and the active physical parameterization is
         stored.
 
+        Every forward solve calls this method again. Once a family has been
+        materialized by :meth:`_set_physical_parameterization` the independent
+        fields are owned by this solver, so they are kept as they are rather
+        than rebuilt from the dictionary: they hold the current values, and
+        rebuilding them would break the identity that pyadjoint controls and
+        already assembled forms rely on.
+
         Parameters
         ----------
         synthetic_data_dict : dict
@@ -76,7 +121,7 @@ class IsotropicWave(ElasticWave):
             and ``mu`` (or ``lame_second``); or ``density``,
             ``p_wave_velocity``, and ``s_wave_velocity``. Values may be
             scalars, Firedrake ``Constant`` objects, Firedrake ``Function``
-            objects, or UFL expressions.
+            objects, or UFL expressions. The dictionary is only read from.
 
         Returns
         -------
@@ -84,6 +129,10 @@ class IsotropicWave(ElasticWave):
             The method assigns ``rho``, ``lmbda``, ``mu``, ``c``, ``c_s``, and
             the active physical parameterization on ``self``.
         """
+        if self._materialized_parameterization is not None:
+            self._register_physical_parameters()
+            return
+
         def material_parameter(value):
             """Normalize model-dictionary values for elastic parameters.
 
@@ -165,12 +214,7 @@ class IsotropicWave(ElasticWave):
                 "The valid options are {Density, Lame first, Lame second} "
                 "or (exclusive) {Density, P-wave velocity, S-wave velocity}",
             )
-        add = self._physical_parameters.add
-        add(ElasticMaterialParameter.DENSITY, self.rho)
-        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
-        add(ElasticMaterialParameter.MU, self.mu)
-        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
-        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
+        self._register_physical_parameters()
 
     def _material_parameter_space(self) -> object:
         """Return the scalar space used for material parameters.
@@ -197,55 +241,40 @@ class IsotropicWave(ElasticWave):
             self._material_parameter_function_space = space
         return space
 
-    def _record_parameterization(
-        self, parameterization: ElasticMaterialParameterization,
-    ) -> None:
-        """Persist independent fields for the next forward initialization.
+    def _register_physical_parameters(self) -> None:
+        """Publish the material fields under their parameter names.
 
-        ``forward_solve`` reads the material dictionary again. Storing the
-        actual independent ``Function`` objects preserves their identity across
-        model initialization.
-
-        Parameters
-        ----------
-        parameterization : ElasticMaterialParameterization
-            Independent family to write to ``synthetic_data``.
+        Both independent fields and the expressions computed from them are
+        registered, so callers can read any elastic parameter regardless of
+        which family the equation is currently written in.
 
         Returns
         -------
         None
         """
-        synthetic_data = self.input_dictionary["synthetic_data"]
-        for parameter in ElasticMaterialParameter:
-            synthetic_data.pop(parameter.value, None)
-        synthetic_data.pop("lame_first", None)
-        synthetic_data.pop("lame_second", None)
-        if parameterization is ElasticMaterialParameterization.LAME:
-            synthetic_data[ElasticMaterialParameter.DENSITY.value] = self.rho
-            synthetic_data[ElasticMaterialParameter.LAMBDA.value] = self.lmbda
-            synthetic_data[ElasticMaterialParameter.MU.value] = self.mu
-        elif parameterization is ElasticMaterialParameterization.VELOCITY:
-            synthetic_data[ElasticMaterialParameter.DENSITY.value] = self.rho
-            synthetic_data[
-                ElasticMaterialParameter.P_WAVE_VELOCITY.value
-            ] = self.c
-            synthetic_data[
-                ElasticMaterialParameter.S_WAVE_VELOCITY.value
-            ] = self.c_s
-        else:
-            raise ValueError(
-                "Unsupported elastic material parameterization: "
-                f"{parameterization}.",
-            )
+        add = self._physical_parameters.add
+        add(ElasticMaterialParameter.DENSITY, self.rho)
+        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
+        add(ElasticMaterialParameter.MU, self.mu)
+        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
+        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
 
     def _set_physical_parameterization(
         self, parameterization: ElasticMaterialParameterization,
     ) -> None:
         """Materialize one independent elastic parameter family.
 
-        This change of variables occurs before tape recording. The target
-        family becomes three scalar ``Function`` objects and the complementary
-        family remains algebraically linked through UFL expressions.
+        The target family becomes three scalar ``Function`` objects and the
+        complementary family is relinked to them through UFL expressions, so
+        updating an independent field carries through to the dependent ones
+        and to the assembled variational forms.
+
+        Once a family has been materialized the fields belong to this object
+        rather than to the model dictionary: they may be registered as
+        pyadjoint controls, and rebuilding them from the dictionary would
+        both discard the current values and orphan those controls. This is
+        why ``_materialized_parameterization`` makes
+        :meth:`initialize_model_parameters_from_object` keep them.
 
         Parameters
         ----------
@@ -255,45 +284,34 @@ class IsotropicWave(ElasticWave):
         Returns
         -------
         None
-        """
-        if parameterization is self._physical_parameterization:
-            # Model dictionaries often contain scalars. Replace them with the
-            # initialized fields so forward_solve() does not create new
-            # Functions and invalidate external references to these fields.
-            self._record_parameterization(parameterization)
-            return
 
+        Raises
+        ------
+        ValueError
+            If the family is not one this solver supports.
+        """
         space = self._material_parameter_space()
+
+        def as_field(value, parameter):
+            """Return ``value`` as an independent field of ``parameter``."""
+            if isinstance(value, Function):
+                return value
+            return Function(space, name=parameter.value).interpolate(value)
+
         if parameterization is ElasticMaterialParameterization.LAME:
-            if not isinstance(self.rho, Function):
-                self.rho = Function(
-                    space, name=ElasticMaterialParameter.DENSITY.value,
-                ).interpolate(self.rho)
-            if not isinstance(self.lmbda, Function):
-                self.lmbda = Function(
-                    space, name=ElasticMaterialParameter.LAMBDA.value,
-                ).interpolate(self.lmbda)
-            if not isinstance(self.mu, Function):
-                self.mu = Function(
-                    space, name=ElasticMaterialParameter.MU.value,
-                ).interpolate(self.mu)
+            self.rho = as_field(self.rho, ElasticMaterialParameter.DENSITY)
+            self.lmbda = as_field(self.lmbda, ElasticMaterialParameter.LAMBDA)
+            self.mu = as_field(self.mu, ElasticMaterialParameter.MU)
             self.c = ((self.lmbda + 2*self.mu)/self.rho)**0.5
             self.c_s = (self.mu/self.rho)**0.5
         elif parameterization is ElasticMaterialParameterization.VELOCITY:
-            if not isinstance(self.rho, Function):
-                self.rho = Function(
-                    space, name=ElasticMaterialParameter.DENSITY.value,
-                ).interpolate(self.rho)
-            if not isinstance(self.c, Function):
-                self.c = Function(
-                    space,
-                    name=ElasticMaterialParameter.P_WAVE_VELOCITY.value,
-                ).interpolate(self.c)
-            if not isinstance(self.c_s, Function):
-                self.c_s = Function(
-                    space,
-                    name=ElasticMaterialParameter.S_WAVE_VELOCITY.value,
-                ).interpolate(self.c_s)
+            self.rho = as_field(self.rho, ElasticMaterialParameter.DENSITY)
+            self.c = as_field(
+                self.c, ElasticMaterialParameter.P_WAVE_VELOCITY,
+            )
+            self.c_s = as_field(
+                self.c_s, ElasticMaterialParameter.S_WAVE_VELOCITY,
+            )
             self.mu = self.rho*self.c_s**2
             self.lmbda = self.rho*self.c**2 - 2*self.mu
         else:
@@ -303,13 +321,89 @@ class IsotropicWave(ElasticWave):
             )
 
         self._physical_parameterization = parameterization
-        add = self._physical_parameters.add
-        add(ElasticMaterialParameter.DENSITY, self.rho)
-        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
-        add(ElasticMaterialParameter.MU, self.mu)
-        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
-        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
-        self._record_parameterization(parameterization)
+        self._materialized_parameterization = parameterization
+        self._register_physical_parameters()
+
+    def select_physical_parameters(
+        self, names: object = None,
+    ) -> PhysicalParameters:
+        """Resolve an independent isotropic-elastic selection.
+
+        An isotropic elastic medium is written either in terms of
+        ``{density, lambda, mu}`` or of
+        ``{density, p_wave_velocity, s_wave_velocity}``, and carries the family
+        it is not written in as expressions of the other. A selection is
+        therefore valid when it fits inside one family, and asking for names
+        from the family currently held as expressions changes the equation over
+        to it.
+
+        Parameters
+        ----------
+        names : ElasticMaterialParameter or iterable, optional
+            Elastic parameters to resolve. ``None`` selects the whole family
+            the equation is currently written in.
+
+        Returns
+        -------
+        PhysicalParameters
+            Selected names, mapped to the independent fields carrying them.
+
+        Raises
+        ------
+        ValueError
+            If the selection is empty, repeats a name, or spans both families.
+        TypeError
+            If a name is not an :class:`ElasticMaterialParameter` member.
+        """
+        current = self._physical_parameterization
+        if current is None:
+            raise ValueError(
+                "Elastic material parameters have not been initialized. "
+                "Call initialize_physical_parameters() first.",
+            )
+        if names is None:
+            selected_names = list(PHYSICAL_PARAMETERIZATION[current])
+        elif isinstance(names, ElasticMaterialParameter):
+            selected_names = [names]
+        else:
+            selected_names = list(names)
+
+        if not selected_names:
+            raise ValueError("At least one elastic control parameter is required.")
+        if not all(
+            isinstance(name, ElasticMaterialParameter)
+            for name in selected_names
+        ):
+            raise TypeError(
+                "Elastic controls must be ElasticMaterialParameter enum "
+                "members.",
+            )
+        if len(set(selected_names)) != len(selected_names):
+            raise ValueError("Elastic control parameters must be unique.")
+
+        wanted = set(selected_names)
+        candidates = [
+            parameterization
+            for parameterization, family in PHYSICAL_PARAMETERIZATION.items()
+            if wanted <= set(family)
+        ]
+        if not candidates:
+            families = " or ".join(
+                _format_physical_parameters(family)
+                for family in PHYSICAL_PARAMETERIZATION.values()
+            )
+            raise ValueError(
+                f"Elastic controls must be a subset of either {families}; "
+                f"got {_format_physical_parameters(selected_names)}.",
+            )
+        target = current if current in candidates else candidates[0]
+        self._set_physical_parameterization(target)
+
+        selected = PhysicalParameters()
+        for parameter in PHYSICAL_PARAMETERIZATION[target]:
+            if parameter in wanted:
+                selected.add(parameter, self.physical_parameters[parameter])
+        return selected
 
     def gradient_solve(
         self,

--- a/spyro/solvers/elastic_wave/isotropic_wave.py
+++ b/spyro/solvers/elastic_wave/isotropic_wave.py
@@ -130,7 +130,6 @@ class IsotropicWave(ElasticWave):
             the active physical parameterization on ``self``.
         """
         if self._materialized_parameterization is not None:
-            self._register_physical_parameters()
             return
 
         def material_parameter(value):
@@ -214,7 +213,12 @@ class IsotropicWave(ElasticWave):
                 "The valid options are {Density, Lame first, Lame second} "
                 "or (exclusive) {Density, P-wave velocity, S-wave velocity}",
             )
-        self._register_physical_parameters()
+        add = self._physical_parameters.add
+        add(ElasticMaterialParameter.DENSITY, self.rho)
+        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
+        add(ElasticMaterialParameter.MU, self.mu)
+        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
+        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
 
     def _material_parameter_space(self) -> object:
         """Return the scalar space used for material parameters.
@@ -240,24 +244,6 @@ class IsotropicWave(ElasticWave):
             )
             self._material_parameter_function_space = space
         return space
-
-    def _register_physical_parameters(self) -> None:
-        """Publish the material fields under their parameter names.
-
-        Both independent fields and the expressions computed from them are
-        registered, so callers can read any elastic parameter regardless of
-        which family the equation is currently written in.
-
-        Returns
-        -------
-        None
-        """
-        add = self._physical_parameters.add
-        add(ElasticMaterialParameter.DENSITY, self.rho)
-        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
-        add(ElasticMaterialParameter.MU, self.mu)
-        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
-        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
 
     def _set_physical_parameterization(
         self, parameterization: ElasticMaterialParameterization,
@@ -322,7 +308,12 @@ class IsotropicWave(ElasticWave):
 
         self._physical_parameterization = parameterization
         self._materialized_parameterization = parameterization
-        self._register_physical_parameters()
+        add = self._physical_parameters.add
+        add(ElasticMaterialParameter.DENSITY, self.rho)
+        add(ElasticMaterialParameter.LAMBDA, self.lmbda)
+        add(ElasticMaterialParameter.MU, self.mu)
+        add(ElasticMaterialParameter.P_WAVE_VELOCITY, self.c)
+        add(ElasticMaterialParameter.S_WAVE_VELOCITY, self.c_s)
 
     def select_physical_parameters(
         self, names: object = None,

--- a/spyro/solvers/inversion.py
+++ b/spyro/solvers/inversion.py
@@ -473,7 +473,7 @@ class FullWaveformInversion:
            an inversion that has not been told otherwise inverts for
            everything the wave equation is written in terms of.
         3. The parameters the solver *class* declares, when the solver has not
-           built its material fields either. Those fields only exist after the
+           built its physical parameters either. Those only exist after the
            first forward solve, but their names are known from the start, and
            they are the same set.
 
@@ -632,8 +632,8 @@ class FullWaveformInversion:
         Parameters
         ----------
         wave : Wave
-            Solver to read the physical parameters from. Its material fields
-            are built first if they do not exist yet.
+            Solver to read the physical parameters from. They are built
+            first if they do not exist yet.
 
         Returns
         -------

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -778,9 +778,9 @@ class Wave(Model_parameters, metaclass=ABCMeta):
     def physical_parameters(self):
         """Return the physical parameters of the wave equation being solved.
 
-        The parameters are the material fields the variational form is written
-        in terms of: the velocity model for an acoustic medium, density and a
-        pair of elastic moduli or wave speeds for an isotropic elastic one.
+        These are the fields the variational form is written in terms of:
+        the velocity model for an acoustic medium, density and a pair of
+        elastic moduli or wave speeds for an isotropic elastic one.
         Solvers declare them while initializing their material properties.
 
         A wave solver knows only about physical parameters. Which of them an
@@ -901,7 +901,7 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         return selected
 
     def initialize_physical_parameters(self):
-        """Build the material fields of the wave equation from the model input.
+        """Build the physical parameters of the wave equation from the model input.
 
         The forward solve does this on its own, so this is only needed to read
         the physical parameters of a solver that has not run yet.

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -797,10 +797,12 @@ class Wave(Model_parameters, metaclass=ABCMeta):
     def physical_parameters(self):
         """Return the physical parameters of the wave equation being solved.
 
-        These are the fields the variational form is written in terms of:
-        the velocity model for an acoustic medium, density and a pair of
-        elastic moduli or wave speeds for an isotropic elastic one.
-        Solvers declare them while initializing their material properties.
+        These are the material fields the solver reads: the velocity model
+        for an acoustic medium; density, the Lame parameters and the two
+        wave speeds for an isotropic elastic one, where the variational form
+        reads the moduli and the absorbing boundary conditions read the
+        speeds. Solvers declare them while initializing their material
+        properties.
 
         A wave solver knows only about physical parameters. Which of them an
         inversion treats as unknowns is a property of the inversion, not of
@@ -837,15 +839,19 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         return parameters
 
     def set_physical_parameterization(self, parameterization) -> None:
-        """Set which physical parameters the equation is solved in terms of.
+        """Set which physical parameters carry the material data.
 
         Some media admit more than one set of physical parameters -- an
         isotropic elastic one is described by density with the Lame
-        parameters, or by density with the two wave speeds -- and carry the
-        set they are not solved in terms of as expressions of the other.
-        Only the set in use can be differentiated with respect to, so this
-        choice belongs to the equation and is made before any parameter is
-        selected as a control.
+        parameters, or by density with the two wave speeds. The solver reads
+        all of them whatever this is set to; what it chooses is which ones
+        hold the data as fields, the rest being expressions computed from
+        those.
+
+        Only a field has degrees of freedom to perturb, so this decides what
+        can be differentiated with respect to, not what the equation is
+        solved for. It is a decision about the equation, made before any
+        parameter is selected as a control.
 
         Initializing the material properties already picks a set, by reading
         whichever one the model input declares. This method is public because
@@ -860,7 +866,7 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         Parameters
         ----------
         parameterization : enum.Enum
-            Set of physical parameters to solve in terms of.
+            Set of physical parameters to carry the data.
 
         Returns
         -------

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -633,8 +633,20 @@ class Wave(Model_parameters, metaclass=ABCMeta):
     def store_forward_time_steps(self, value):
         self._store_forward_time_steps = value
 
-    def enable_automated_adjoint(self) -> None:
+    def enable_automated_adjoint(self, control_parameters=None) -> None:
         """Enable the automated-adjoint solver.
+
+        The parameters to differentiate with respect to are resolved here,
+        against the physical parameters the equation is currently written in,
+        so an invalid selection fails before any adjoint state exists.
+
+        Parameters
+        ----------
+        control_parameters : enum.Enum or iterable of enum.Enum, optional
+            Physical parameters to differentiate with respect to. ``None``
+            takes every parameter the equation offers. Names the equation
+            does not carry as independent fields are rejected; changing which
+            ones it does is :meth:`set_physical_parameterization`.
 
         Returns
         -------
@@ -653,7 +665,7 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         # ``EnsembleReducedFunctional``, summing the per-shot functionals and
         # gradients over the ensemble communicator.
         self.automated_adjoint = AutomatedAdjoint(
-            self.comm, select_parameters=self._select_physical_parameters,
+            self.comm, self._select_physical_parameters(control_parameters),
         )
         self.functional_value = None
         self.misfit = None

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -185,10 +185,6 @@ class Wave(Model_parameters, metaclass=ABCMeta):
                                     lambda: self.get_function())
 
         self._physical_parameters = PhysicalParameters()
-        #: Family of physical parameters the equation is written in, for
-        #: equations that admit more than one. ``None`` when there is only
-        #: one, so there is nothing to choose.
-        self._physical_parameterization = None
         #: Whether the physical parameters already exist as the ``Function``
         #: objects this solver goes on using.
         #:

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -827,13 +827,14 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         parameters it wants, but only the wave equation knows how they are
         related: which ones it carries as independent
         :class:`firedrake.Function` fields and which ones it computes from
-        those. Resolving a selection is therefore its responsibility, and
-        subclasses whose parameters admit more than one independent family
-        override this method to reconcile the selection with the family in use.
+        those. Resolving a selection is therefore its responsibility. A
+        selection is valid when every name in it is carried by an independent
+        field, which for an equation that can be written in more than one
+        family means the family it is currently written in.
 
-        This base implementation covers wave equations whose parameters are
-        independent of one another, so a selection is valid exactly when every
-        name in it is carried by an independent field.
+        Deciding *which* parameters an inversion or an adjoint controls is
+        not this method's business; it only answers whether the equation, as
+        currently written, can offer them.
 
         Parameters
         ----------
@@ -894,8 +895,11 @@ class Wave(Model_parameters, metaclass=ABCMeta):
             field = physical_parameters[name]
             if not isinstance(field, fire.Function):
                 raise TypeError(
-                    f"'{name.value}' is a dependent physical parameter and "
-                    "cannot be used directly as a control.",
+                    f"'{name.value}' is computed from the other physical "
+                    "parameters of this wave equation, so it cannot be "
+                    "controlled on its own. If the equation can be written "
+                    "in terms of it instead, change its physical "
+                    "parameterization first.",
                 )
             selected.add(name, field)
         return selected

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -185,16 +185,6 @@ class Wave(Model_parameters, metaclass=ABCMeta):
                                     lambda: self.get_function())
 
         self._physical_parameters = PhysicalParameters()
-        #: Whether the physical parameters already exist as the ``Function``
-        #: objects this solver goes on using.
-        #:
-        #: Solvers that rebuild their parameters from the model input on
-        #: every forward solve must stop once this is set: by then the
-        #: adjoint is posed with respect to those exact objects, and an
-        #: inversion has written its current iterate into them. Rebuilding
-        #: would differentiate with respect to objects the forward solve no
-        #: longer uses, and reset the iterate to the model's initial values.
-        self._physical_parameters_are_built = False
 
     def forward_solve(self):
         """Solves the forward problem."""
@@ -662,9 +652,6 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         # Resolve the selection first: an invalid one must fail before any
         # adjoint state exists to be left half-built.
         controls = self.physical_parameters.select(control_parameters)
-        # These fields are controls now, so whatever builds the physical
-        # parameters must stop replacing them.
-        self._physical_parameters_are_built = True
         # ``self.comm`` is the Firedrake ``Ensemble`` distributing the shots
         # across ensemble members. It is forwarded to ``AutomatedAdjoint`` so
         # that the reduced functional is built as an
@@ -850,24 +837,30 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         return parameters
 
     def set_physical_parameterization(self, parameterization) -> None:
-        """Write the equation in one of its physical parameter families.
+        """Set which physical parameters the equation is solved in terms of.
 
-        Some media can be described by more than one set of physical
-        parameters -- an isotropic elastic one by density with the Lame
-        parameters, or by density with the two wave speeds -- carrying
-        whichever set it is not written in as expressions of the other. Only
-        the set in use can be controlled, so choosing between them is a
-        decision about the equation, made before anything selects parameters
-        to differentiate with respect to.
+        Some media admit more than one set of physical parameters -- an
+        isotropic elastic one is described by density with the Lame
+        parameters, or by density with the two wave speeds -- and carry the
+        set they are not solved in terms of as expressions of the other.
+        Only the set in use can be differentiated with respect to, so this
+        choice belongs to the equation and is made before any parameter is
+        selected as a control.
 
-        The choice is deliberate, so it also pins the fields: the model input
-        declares one family, and letting the next initialization read it
-        again would silently undo this call.
+        Initializing the material properties already picks a set, by reading
+        whichever one the model input declares. This method is public because
+        that first choice is worth revising: an inversion is not obliged to
+        invert in the parameters its model happens to be stored in, and which
+        set it uses changes the conditioning of the problem and the cross-talk
+        between parameters. Exposing the change of variables keeps it in the
+        solver, where it is the same one initialization performs, rather than
+        leaving callers to convert their model input by hand and get a factor
+        or a sign wrong.
 
         Parameters
         ----------
         parameterization : enum.Enum
-            Family to write the equation in.
+            Set of physical parameters to solve in terms of.
 
         Returns
         -------
@@ -876,34 +869,9 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         Raises
         ------
         NotImplementedError
-            If this equation is written in a single set of parameters.
+            If this equation admits a single set of physical parameters.
         ValueError
-            If the family is not one this solver supports.
-        """
-        self._build_physical_parameterization(parameterization)
-        self._physical_parameters_are_built = True
-
-    def _build_physical_parameterization(self, parameterization) -> None:
-        """Materialize one physical parameter family.
-
-        Subclasses whose medium admits more than one family implement this
-        with the change of variables between them. It is separate from
-        :meth:`set_physical_parameterization` because initialization builds
-        the declared family on every solve, and must not pin it.
-
-        Parameters
-        ----------
-        parameterization : enum.Enum
-            Family to write the equation in.
-
-        Returns
-        -------
-        None
-
-        Raises
-        ------
-        NotImplementedError
-            Always, unless a subclass implements it.
+            If the set of parameters is not one this solver supports.
         """
         raise NotImplementedError(
             f"{type(self).__name__} is written in a single set of physical "

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod, ABCMeta
-from enum import Enum
 import warnings
 import firedrake as fire
 
@@ -659,14 +658,23 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         self.adjoint_type = AdjointType.AUTOMATED_ADJOINT
         self.use_vertex_only_mesh = True
         self._initialize_model_parameters()
+        if self.mesh is None:
+            raise ValueError(
+                "Mesh must be set before enabling the automated adjoint: "
+                "a control has to be a field.",
+            )
+        # Resolve the selection first: an invalid one must fail before any
+        # adjoint state exists to be left half-built.
+        controls = self.physical_parameters.select(control_parameters)
+        # These fields are controls now, so whatever builds the physical
+        # parameters must stop replacing them.
+        self._physical_parameters_are_built = True
         # ``self.comm`` is the Firedrake ``Ensemble`` distributing the shots
         # across ensemble members. It is forwarded to ``AutomatedAdjoint`` so
         # that the reduced functional is built as an
         # ``EnsembleReducedFunctional``, summing the per-shot functionals and
         # gradients over the ensemble communicator.
-        self.automated_adjoint = AutomatedAdjoint(
-            self.comm, self._select_physical_parameters(control_parameters),
-        )
+        self.automated_adjoint = AutomatedAdjoint(self.comm, controls)
         self.functional_value = None
         self.misfit = None
 
@@ -905,102 +913,6 @@ class Wave(Model_parameters, metaclass=ABCMeta):
             f"{type(self).__name__} is written in a single set of physical "
             "parameters, so there is no parameterization to choose.",
         )
-
-    def _select_physical_parameters(
-        self, names: object = None,
-    ) -> PhysicalParameters:
-        """Resolve ``names`` to the independent fields they are carried by.
-
-        Anything that differentiates the wave equation with respect to its
-        material properties -- an inversion, the automated adjoint -- names the
-        parameters it wants, but only the wave equation knows how they are
-        related: which ones it carries as independent
-        :class:`firedrake.Function` fields and which ones it computes from
-        those. Resolving a selection is therefore its responsibility. A
-        selection is valid when every name in it is carried by an independent
-        field, which for an equation that can be written in more than one
-        family means the family it is currently written in.
-
-        Deciding *which* parameters an inversion or an adjoint controls is
-        not this method's business; it only answers whether the equation, as
-        currently written, can offer them.
-
-        Parameters
-        ----------
-        names : enum.Enum or iterable of enum.Enum, optional
-            Material parameters to resolve. ``None`` selects every independent
-            parameter of the wave equation.
-
-        Returns
-        -------
-        PhysicalParameters
-            Selected names, mapped to the independent fields carrying them.
-
-        Raises
-        ------
-        ValueError
-            If the selection is empty, or names a parameter this wave equation
-            does not model.
-        TypeError
-            If a name is not a material-parameter enum member, or names a
-            parameter computed from the independent ones.
-        """
-        if self.mesh is None:
-            raise ValueError(
-                "Mesh must be set before selecting physical parameters: "
-                "a control has to be a field.",
-            )
-        physical_parameters = self.physical_parameters
-        if names is None:
-            selected_names = [
-                name for name, value in physical_parameters.items()
-                if isinstance(value, fire.Function)
-            ]
-            if not selected_names:
-                raise ValueError(
-                    f"{type(self).__name__} carries no independent physical "
-                    "parameter to differentiate with respect to. Set its "
-                    "material properties first, for instance through "
-                    "set_initial_velocity_model().",
-                )
-        elif isinstance(names, Enum):
-            selected_names = [names]
-        else:
-            selected_names = list(names)
-
-        if not selected_names:
-            raise ValueError("At least one control parameter is required.")
-        if not all(isinstance(name, Enum) for name in selected_names):
-            raise TypeError(
-                "Control parameters must be material-parameter enum members.",
-            )
-        unknown = set(selected_names) - set(physical_parameters)
-        if unknown:
-            formatted = ", ".join(name.value for name in unknown)
-            raise ValueError(
-                f"Control parameters {{{formatted}}} are not physical "
-                "parameters of this wave equation.",
-            )
-
-        selected = PhysicalParameters()
-        for name in physical_parameters:
-            if name not in selected_names:
-                continue
-            field = physical_parameters[name]
-            if not isinstance(field, fire.Function):
-                raise TypeError(
-                    f"'{name.value}' is computed from the other physical "
-                    "parameters of this wave equation, so it cannot be "
-                    "controlled on its own. If the equation can be written "
-                    "in terms of it instead, change its physical "
-                    "parameterization first.",
-                )
-            selected.add(name, field)
-        # The selected fields are about to be differentiated with respect to,
-        # or written into by an inversion. Either way whatever builds the
-        # physical parameters must stop replacing them.
-        self._physical_parameters_are_built = True
-        return selected
 
     def initialize_physical_parameters(self):
         """Build the physical parameters of the wave equation from the model input.

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -630,8 +630,9 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         control_parameters : enum.Enum or iterable of enum.Enum, optional
             Physical parameters to differentiate with respect to. ``None``
             takes every parameter the equation offers. Names the equation
-            does not carry as independent fields are rejected; changing which
-            ones it does is :meth:`set_physical_parameterization`.
+            does not carry as independent fields are rejected. Solvers whose
+            medium admits more than one set of parameters offer
+            ``set_physical_parameterization`` to change which ones do.
 
         Returns
         -------
@@ -837,52 +838,6 @@ class Wave(Model_parameters, metaclass=ABCMeta):
                 "physical parameters have been defined."
             )
         return parameters
-
-    def set_physical_parameterization(self, parameterization) -> None:
-        """Set which physical parameters carry the material data.
-
-        Some media admit more than one set of physical parameters -- an
-        isotropic elastic one is described by density with the Lame
-        parameters, or by density with the two wave speeds. The solver reads
-        all of them whatever this is set to; what it chooses is which ones
-        hold the data as fields, the rest being expressions computed from
-        those.
-
-        Only a field has degrees of freedom to perturb, so this decides what
-        can be differentiated with respect to, not what the equation is
-        solved for. It is a decision about the equation, made before any
-        parameter is selected as a control.
-
-        Initializing the material properties already picks a set, by reading
-        whichever one the model input declares. This method is public because
-        that first choice is worth revising: an inversion is not obliged to
-        invert in the parameters its model happens to be stored in, and which
-        set it uses changes the conditioning of the problem and the cross-talk
-        between parameters. Exposing the change of variables keeps it in the
-        solver, where it is the same one initialization performs, rather than
-        leaving callers to convert their model input by hand and get a factor
-        or a sign wrong.
-
-        Parameters
-        ----------
-        parameterization : enum.Enum
-            Set of physical parameters to carry the data.
-
-        Returns
-        -------
-        None
-
-        Raises
-        ------
-        NotImplementedError
-            If this equation admits a single set of physical parameters.
-        ValueError
-            If the set of parameters is not one this solver supports.
-        """
-        raise NotImplementedError(
-            f"{type(self).__name__} is written in a single set of physical "
-            "parameters, so there is no parameterization to choose.",
-        )
 
     def initialize_physical_parameters(self):
         """Build the physical parameters of the wave equation from the model input.

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod, ABCMeta
+from enum import Enum
 import warnings
 import firedrake as fire
 
@@ -815,6 +816,89 @@ class Wave(Model_parameters, metaclass=ABCMeta):
                 "physical parameters have been defined."
             )
         return parameters
+
+    def select_physical_parameters(
+        self, names: object = None,
+    ) -> PhysicalParameters:
+        """Resolve ``names`` to the independent fields they are carried by.
+
+        Anything that differentiates the wave equation with respect to its
+        material properties -- an inversion, the automated adjoint -- names the
+        parameters it wants, but only the wave equation knows how they are
+        related: which ones it carries as independent
+        :class:`firedrake.Function` fields and which ones it computes from
+        those. Resolving a selection is therefore its responsibility, and
+        subclasses whose parameters admit more than one independent family
+        override this method to reconcile the selection with the family in use.
+
+        This base implementation covers wave equations whose parameters are
+        independent of one another, so a selection is valid exactly when every
+        name in it is carried by an independent field.
+
+        Parameters
+        ----------
+        names : enum.Enum or iterable of enum.Enum, optional
+            Material parameters to resolve. ``None`` selects every independent
+            parameter of the wave equation.
+
+        Returns
+        -------
+        PhysicalParameters
+            Selected names, mapped to the independent fields carrying them.
+
+        Raises
+        ------
+        ValueError
+            If the selection is empty, or names a parameter this wave equation
+            does not model.
+        TypeError
+            If a name is not a material-parameter enum member, or names a
+            parameter computed from the independent ones.
+        """
+        physical_parameters = self.physical_parameters
+        if names is None:
+            selected_names = [
+                name for name, value in physical_parameters.items()
+                if isinstance(value, fire.Function)
+            ]
+            if not selected_names:
+                raise ValueError(
+                    f"{type(self).__name__} carries no independent physical "
+                    "parameter to differentiate with respect to. Set its "
+                    "material properties first, for instance through "
+                    "set_initial_velocity_model().",
+                )
+        elif isinstance(names, Enum):
+            selected_names = [names]
+        else:
+            selected_names = list(names)
+
+        if not selected_names:
+            raise ValueError("At least one control parameter is required.")
+        if not all(isinstance(name, Enum) for name in selected_names):
+            raise TypeError(
+                "Control parameters must be material-parameter enum members.",
+            )
+        unknown = set(selected_names) - set(physical_parameters)
+        if unknown:
+            formatted = ", ".join(name.value for name in unknown)
+            raise ValueError(
+                f"Control parameters {{{formatted}}} are not physical "
+                "parameters of this wave equation.",
+            )
+
+        selected = PhysicalParameters()
+        for name in physical_parameters:
+            if name not in selected_names:
+                continue
+            field = physical_parameters[name]
+            if not isinstance(field, fire.Function):
+                raise TypeError(
+                    f"'{name.value}' is a dependent physical parameter and "
+                    "cannot be used directly as a control.",
+                )
+            selected.add(name, field)
+        return selected
 
     def initialize_physical_parameters(self):
         """Build the material fields of the wave equation from the model input.

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -652,7 +652,9 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         # that the reduced functional is built as an
         # ``EnsembleReducedFunctional``, summing the per-shot functionals and
         # gradients over the ensemble communicator.
-        self.automated_adjoint = AutomatedAdjoint(self.comm, wave=self)
+        self.automated_adjoint = AutomatedAdjoint(
+            self.comm, select_parameters=self._select_physical_parameters,
+        )
         self.functional_value = None
         self.misfit = None
 
@@ -831,18 +833,6 @@ class Wave(Model_parameters, metaclass=ABCMeta):
             )
         return parameters
 
-    @property
-    def physical_parameterization(self):
-        """Return the family of physical parameters the equation uses.
-
-        Returns
-        -------
-        enum.Enum or None
-            Active family, or ``None`` for an equation written in a single
-            set of physical parameters.
-        """
-        return self._physical_parameterization
-
     def set_physical_parameterization(self, parameterization) -> None:
         """Write the equation in one of its physical parameter families.
 
@@ -904,7 +894,7 @@ class Wave(Model_parameters, metaclass=ABCMeta):
             "parameters, so there is no parameterization to choose.",
         )
 
-    def select_physical_parameters(
+    def _select_physical_parameters(
         self, names: object = None,
     ) -> PhysicalParameters:
         """Resolve ``names`` to the independent fields they are carried by.

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod, ABCMeta
-from enum import Enum
 import warnings
 import firedrake as fire
 
@@ -619,80 +618,8 @@ class Wave(Model_parameters, metaclass=ABCMeta):
     def store_forward_time_steps(self, value):
         self._store_forward_time_steps = value
 
-    def _select_control_parameters(
-        self, parameters: object = None,
-    ) -> PhysicalParameters:
-        """Resolve physical parameters into independent adjoint controls.
-
-        Parameters
-        ----------
-        parameters : enum.Enum or iterable of enum.Enum, optional
-            Physical parameters selected as controls. ``None`` selects every
-            independent physical field.
-
-        Returns
-        -------
-        PhysicalParameters
-            Selected parameter names and the fields used by the wave equation.
-
-        Raises
-        ------
-        TypeError
-            If a selected name is not a material-parameter enum member or its
-            value is not an independent Firedrake ``Function``.
-        ValueError
-            If the selection is empty or contains a parameter not modelled by
-            this wave equation.
-        """
-        physical_parameters = self.physical_parameters
-        if parameters is None:
-            selected_names = [
-                name for name, value in physical_parameters.items()
-                if isinstance(value, fire.Function)
-            ]
-        elif isinstance(parameters, Enum):
-            selected_names = [parameters]
-        else:
-            selected_names = list(parameters)
-
-        if not selected_names:
-            raise ValueError("At least one control parameter is required.")
-        if not all(isinstance(name, Enum) for name in selected_names):
-            raise TypeError(
-                "Control parameters must be material-parameter enum members.",
-            )
-
-        unknown = set(selected_names) - set(physical_parameters)
-        if unknown:
-            names = ", ".join(name.value for name in unknown)
-            raise ValueError(
-                f"Control parameters {{{names}}} are not physical "
-                "parameters of this wave equation.",
-            )
-
-        selected = PhysicalParameters()
-        for name in physical_parameters:
-            if name not in selected_names:
-                continue
-            field = physical_parameters[name]
-            if not isinstance(field, fire.Function):
-                raise TypeError(
-                    f"'{name.value}' is a dependent physical parameter and "
-                    "cannot be used directly as a control.",
-                )
-            selected.add(name, field)
-        return selected
-
-    def enable_automated_adjoint(
-        self, control_parameters: object = None,
-    ) -> None:
-        """Enable automated differentiation for selected physical parameters.
-
-        Parameters
-        ----------
-        control_parameters : enum.Enum or iterable of enum.Enum, optional
-            Non-empty subset of physical parameters to differentiate. The
-            default selects all independent parameters of the wave equation.
+    def enable_automated_adjoint(self) -> None:
+        """Enable the automated-adjoint solver.
 
         Returns
         -------
@@ -705,13 +632,12 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         self.adjoint_type = AdjointType.AUTOMATED_ADJOINT
         self.use_vertex_only_mesh = True
         self._initialize_model_parameters()
-        controls = self._select_control_parameters(control_parameters)
         # ``self.comm`` is the Firedrake ``Ensemble`` distributing the shots
         # across ensemble members. It is forwarded to ``AutomatedAdjoint`` so
         # that the reduced functional is built as an
         # ``EnsembleReducedFunctional``, summing the per-shot functionals and
         # gradients over the ensemble communicator.
-        self.automated_adjoint = AutomatedAdjoint(self.comm, controls)
+        self.automated_adjoint = AutomatedAdjoint(self.comm, wave=self)
         self.functional_value = None
         self.misfit = None
 

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -186,6 +186,20 @@ class Wave(Model_parameters, metaclass=ABCMeta):
                                     lambda: self.get_function())
 
         self._physical_parameters = PhysicalParameters()
+        #: Family of physical parameters the equation is written in, for
+        #: equations that admit more than one. ``None`` when there is only
+        #: one, so there is nothing to choose.
+        self._physical_parameterization = None
+        #: Whether the physical parameters already exist as the ``Function``
+        #: objects this solver goes on using.
+        #:
+        #: Solvers that rebuild their parameters from the model input on
+        #: every forward solve must stop once this is set: by then the
+        #: adjoint is posed with respect to those exact objects, and an
+        #: inversion has written its current iterate into them. Rebuilding
+        #: would differentiate with respect to objects the forward solve no
+        #: longer uses, and reset the iterate to the model's initial values.
+        self._physical_parameters_are_built = False
 
     def forward_solve(self):
         """Solves the forward problem."""
@@ -817,6 +831,79 @@ class Wave(Model_parameters, metaclass=ABCMeta):
             )
         return parameters
 
+    @property
+    def physical_parameterization(self):
+        """Return the family of physical parameters the equation uses.
+
+        Returns
+        -------
+        enum.Enum or None
+            Active family, or ``None`` for an equation written in a single
+            set of physical parameters.
+        """
+        return self._physical_parameterization
+
+    def set_physical_parameterization(self, parameterization) -> None:
+        """Write the equation in one of its physical parameter families.
+
+        Some media can be described by more than one set of physical
+        parameters -- an isotropic elastic one by density with the Lame
+        parameters, or by density with the two wave speeds -- carrying
+        whichever set it is not written in as expressions of the other. Only
+        the set in use can be controlled, so choosing between them is a
+        decision about the equation, made before anything selects parameters
+        to differentiate with respect to.
+
+        The choice is deliberate, so it also pins the fields: the model input
+        declares one family, and letting the next initialization read it
+        again would silently undo this call.
+
+        Parameters
+        ----------
+        parameterization : enum.Enum
+            Family to write the equation in.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        NotImplementedError
+            If this equation is written in a single set of parameters.
+        ValueError
+            If the family is not one this solver supports.
+        """
+        self._build_physical_parameterization(parameterization)
+        self._physical_parameters_are_built = True
+
+    def _build_physical_parameterization(self, parameterization) -> None:
+        """Materialize one physical parameter family.
+
+        Subclasses whose medium admits more than one family implement this
+        with the change of variables between them. It is separate from
+        :meth:`set_physical_parameterization` because initialization builds
+        the declared family on every solve, and must not pin it.
+
+        Parameters
+        ----------
+        parameterization : enum.Enum
+            Family to write the equation in.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        NotImplementedError
+            Always, unless a subclass implements it.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} is written in a single set of physical "
+            "parameters, so there is no parameterization to choose.",
+        )
+
     def select_physical_parameters(
         self, names: object = None,
     ) -> PhysicalParameters:
@@ -856,6 +943,11 @@ class Wave(Model_parameters, metaclass=ABCMeta):
             If a name is not a material-parameter enum member, or names a
             parameter computed from the independent ones.
         """
+        if self.mesh is None:
+            raise ValueError(
+                "Mesh must be set before selecting physical parameters: "
+                "a control has to be a field.",
+            )
         physical_parameters = self.physical_parameters
         if names is None:
             selected_names = [
@@ -902,6 +994,10 @@ class Wave(Model_parameters, metaclass=ABCMeta):
                     "parameterization first.",
                 )
             selected.add(name, field)
+        # The selected fields are about to be differentiated with respect to,
+        # or written into by an inversion. Either way whatever builds the
+        # physical parameters must stop replacing them.
+        self._physical_parameters_are_built = True
         return selected
 
     def initialize_physical_parameters(self):

--- a/spyro/solvers/wave.py
+++ b/spyro/solvers/wave.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod, ABCMeta
+from enum import Enum
 import warnings
 import firedrake as fire
 
@@ -618,7 +619,85 @@ class Wave(Model_parameters, metaclass=ABCMeta):
     def store_forward_time_steps(self, value):
         self._store_forward_time_steps = value
 
-    def enable_automated_adjoint(self):
+    def _select_control_parameters(
+        self, parameters: object = None,
+    ) -> PhysicalParameters:
+        """Resolve physical parameters into independent adjoint controls.
+
+        Parameters
+        ----------
+        parameters : enum.Enum or iterable of enum.Enum, optional
+            Physical parameters selected as controls. ``None`` selects every
+            independent physical field.
+
+        Returns
+        -------
+        PhysicalParameters
+            Selected parameter names and the fields used by the wave equation.
+
+        Raises
+        ------
+        TypeError
+            If a selected name is not a material-parameter enum member or its
+            value is not an independent Firedrake ``Function``.
+        ValueError
+            If the selection is empty or contains a parameter not modelled by
+            this wave equation.
+        """
+        physical_parameters = self.physical_parameters
+        if parameters is None:
+            selected_names = [
+                name for name, value in physical_parameters.items()
+                if isinstance(value, fire.Function)
+            ]
+        elif isinstance(parameters, Enum):
+            selected_names = [parameters]
+        else:
+            selected_names = list(parameters)
+
+        if not selected_names:
+            raise ValueError("At least one control parameter is required.")
+        if not all(isinstance(name, Enum) for name in selected_names):
+            raise TypeError(
+                "Control parameters must be material-parameter enum members.",
+            )
+
+        unknown = set(selected_names) - set(physical_parameters)
+        if unknown:
+            names = ", ".join(name.value for name in unknown)
+            raise ValueError(
+                f"Control parameters {{{names}}} are not physical "
+                "parameters of this wave equation.",
+            )
+
+        selected = PhysicalParameters()
+        for name in physical_parameters:
+            if name not in selected_names:
+                continue
+            field = physical_parameters[name]
+            if not isinstance(field, fire.Function):
+                raise TypeError(
+                    f"'{name.value}' is a dependent physical parameter and "
+                    "cannot be used directly as a control.",
+                )
+            selected.add(name, field)
+        return selected
+
+    def enable_automated_adjoint(
+        self, control_parameters: object = None,
+    ) -> None:
+        """Enable automated differentiation for selected physical parameters.
+
+        Parameters
+        ----------
+        control_parameters : enum.Enum or iterable of enum.Enum, optional
+            Non-empty subset of physical parameters to differentiate. The
+            default selects all independent parameters of the wave equation.
+
+        Returns
+        -------
+        None
+        """
         self.store_forward_time_steps = False
         self.enable_compute_functional(
             mode=FunctionalEvaluationMode.PER_TIMESTEP
@@ -626,13 +705,7 @@ class Wave(Model_parameters, metaclass=ABCMeta):
         self.adjoint_type = AdjointType.AUTOMATED_ADJOINT
         self.use_vertex_only_mesh = True
         self._initialize_model_parameters()
-        if self.c is None:
-            raise ValueError(
-                "self.c must be set before enabling automated adjoint."
-                "Please set the velocity model using set_initial_velocity_model()"
-                "or set c directly."
-            )
-        controls = self.c
+        controls = self._select_control_parameters(control_parameters)
         # ``self.comm`` is the Firedrake ``Ensemble`` distributing the shots
         # across ensemble members. It is forwarded to ``AutomatedAdjoint`` so
         # that the reduced functional is built as an

--- a/spyro/utils/physical_parameters.py
+++ b/spyro/utils/physical_parameters.py
@@ -202,6 +202,79 @@ class PhysicalParameters(Set):
             field.interpolate(value)
         return field
 
+    def select(self, names=None):
+        """Return the independent fields carrying ``names``.
+
+        Only independent parameters can be differentiated with respect to or
+        updated, so a selection is valid exactly when every name in it is
+        carried by a ``Function`` rather than computed from the others.
+
+        The fields are shared, not duplicated: writing into a selected field
+        writes into this container's. Use :meth:`copy` for a detached one.
+
+        Parameters
+        ----------
+        names : enum.Enum or iterable of enum.Enum, optional
+            Parameters to select. ``None`` selects every independent one.
+
+        Returns
+        -------
+        PhysicalParameters
+            Selected names, mapped to the fields carrying them.
+
+        Raises
+        ------
+        ValueError
+            If the selection is empty, or names a parameter not modelled
+            here.
+        TypeError
+            If a name is not a material parameter enum member, or is
+            computed from the independent ones.
+        """
+        if names is None:
+            selected_names = [
+                name for name, value in self._fields.items()
+                if isinstance(value, fire.Function)
+            ]
+            if not selected_names:
+                raise ValueError(
+                    "No independent physical parameter to select: none of "
+                    f"{self._format_names()} has been built as a field yet.",
+                )
+        elif isinstance(names, Enum):
+            selected_names = [names]
+        else:
+            selected_names = list(names)
+
+        if not selected_names:
+            raise ValueError("At least one physical parameter is required.")
+        if not all(isinstance(name, Enum) for name in selected_names):
+            raise TypeError(
+                "Physical parameters are selected by material-parameter "
+                "enum members.",
+            )
+        unknown = set(selected_names) - set(self._fields)
+        if unknown:
+            formatted = "{" + ", ".join(name.value for name in unknown) + "}"
+            raise ValueError(
+                f"{formatted} is not a physical parameter of this wave "
+                f"equation. Known parameters: {self._format_names()}.",
+            )
+
+        selected = PhysicalParameters()
+        for name, field in self._fields.items():
+            if name not in selected_names:
+                continue
+            if not isinstance(field, fire.Function):
+                raise TypeError(
+                    f"'{name.value}' is computed from the other physical "
+                    "parameters, so it cannot be selected on its own. If "
+                    "the wave equation can be written in terms of it "
+                    "instead, change its physical parameterization first.",
+                )
+            selected.add(name, field)
+        return selected
+
     def copy(self, names=None):
         """Return an independent copy of some or all parameters.
 

--- a/spyro/utils/physical_parameters.py
+++ b/spyro/utils/physical_parameters.py
@@ -5,23 +5,6 @@ from enum import Enum
 
 import firedrake as fire
 
-from .typing import (ElasticMaterialParameter,
-                     ElasticMaterialParameterization)
-
-
-ELASTIC_PARAMETERIZATIONS = {
-    ElasticMaterialParameterization.LAME: (
-        ElasticMaterialParameter.DENSITY,
-        ElasticMaterialParameter.LAMBDA,
-        ElasticMaterialParameter.MU,
-    ),
-    ElasticMaterialParameterization.VELOCITY: (
-        ElasticMaterialParameter.DENSITY,
-        ElasticMaterialParameter.P_WAVE_VELOCITY,
-        ElasticMaterialParameter.S_WAVE_VELOCITY,
-    ),
-}
-
 
 def _as_parameter(name):
     """Return ``name`` if it is a material parameter enum member.

--- a/spyro/utils/physical_parameters.py
+++ b/spyro/utils/physical_parameters.py
@@ -268,9 +268,9 @@ class PhysicalParameters(Set):
             if not isinstance(field, fire.Function):
                 raise TypeError(
                     f"'{name.value}' is computed from the other physical "
-                    "parameters, so it cannot be selected on its own. If "
-                    "the wave equation can be written in terms of it "
-                    "instead, change its physical parameterization first.",
+                    "parameters, so it has no data of its own to select. "
+                    "If it can carry the data instead, change the wave "
+                    "equation's physical parameterization first.",
                 )
             selected.add(name, field)
         return selected

--- a/spyro/utils/physical_parameters.py
+++ b/spyro/utils/physical_parameters.py
@@ -5,6 +5,23 @@ from enum import Enum
 
 import firedrake as fire
 
+from .typing import (ElasticMaterialParameter,
+                     ElasticMaterialParameterization)
+
+
+ELASTIC_PARAMETERIZATIONS = {
+    ElasticMaterialParameterization.LAME: (
+        ElasticMaterialParameter.DENSITY,
+        ElasticMaterialParameter.LAMBDA,
+        ElasticMaterialParameter.MU,
+    ),
+    ElasticMaterialParameterization.VELOCITY: (
+        ElasticMaterialParameter.DENSITY,
+        ElasticMaterialParameter.P_WAVE_VELOCITY,
+        ElasticMaterialParameter.S_WAVE_VELOCITY,
+    ),
+}
+
 
 def _as_parameter(name):
     """Return ``name`` if it is a material parameter enum member.

--- a/spyro/utils/utils.py
+++ b/spyro/utils/utils.py
@@ -12,7 +12,7 @@ from ..io.parallelism_wrappers import (
     run_in_one_core_and_broadcast,
 )
 from ..domains.space import create_function_space
-from .typing import FunctionalEvaluationMode, FunctionalType
+from .typing import FunctionalEvaluationMode, FunctionalType, WaveType
 
 
 def butter_lowpass_filter(shot, cutoff, fs, order=2):
@@ -645,7 +645,8 @@ def get_real_shot_record(wave):
     """Get the real shot record for the active sources.
 
     The returned object is typically an array with shape
-    ``(n_timesteps, n_receivers)`` for a single active shot.
+    ``(n_timesteps, n_receivers)`` for a scalar wave or
+    ``(n_timesteps, n_receivers, dimension)`` for a single elastic shot.
     """
     real_shot_record = wave.real_shot_record
 
@@ -664,10 +665,17 @@ def get_real_shot_record(wave):
             "before retrieving the real shot record."
         )
 
+    # Scalar single-shot records have two axes, while vector elastic ones have
+    # three. Multiple shots add exactly one leading axis. Comparing ranks
+    # therefore distinguishes a vector-valued shot from multishot scalar data
+    # without guessing from potentially equal axis lengths.
+    single_shot_ndim = (
+        2 if wave.wave_type is WaveType.ISOTROPIC_ACOUSTIC else 3
+    )
     if isinstance(real_shot_record, np.ndarray):
-        if real_shot_record.ndim == 3:
+        if real_shot_record.ndim == single_shot_ndim + 1:
             return real_shot_record[wave.current_sources[0]]
-        if real_shot_record.ndim == 2:
+        if real_shot_record.ndim == single_shot_ndim:
             return real_shot_record
 
     if isinstance(real_shot_record, (list, tuple)):
@@ -676,7 +684,10 @@ def get_real_shot_record(wave):
             and len(real_shot_record) > wave.current_sources[0]
         ):
             source_record = real_shot_record[wave.current_sources[0]]
-            if isinstance(source_record, np.ndarray) and source_record.ndim == 2:
+            if (
+                isinstance(source_record, np.ndarray)
+                and source_record.ndim == single_shot_ndim
+            ):
                 return source_record
 
     return real_shot_record

--- a/tests/on_one_core/test_elastic_auto_adj_2d.py
+++ b/tests/on_one_core/test_elastic_auto_adj_2d.py
@@ -178,11 +178,19 @@ def test_elastic_automated_adjoint_controls(
             for gradient in gradients.values()
         )
 
+        # A Taylor test only means anything in the asymptotic regime, where
+        # the residual goes as the square of the perturbation. Perturbing by
+        # a full multiple of the control leaves it: the measured rates spread
+        # from 1.93 to 2.43, both directions away from the second order the
+        # test is checking for. A tenth of that brings every case to within
+        # 0.02 of 2.0.
         rng = np.random.default_rng(42)
         directions = [
             fire.Function(
                 control.function_space(),
-                val=control.dat.data_ro * rng.random(control.dat.data_ro.shape),
+                val=0.1 * control.dat.data_ro * rng.random(
+                    control.dat.data_ro.shape,
+                ),
             )
             for control in wave.automated_adjoint.controls
         ]

--- a/tests/on_one_core/test_elastic_auto_adj_2d.py
+++ b/tests/on_one_core/test_elastic_auto_adj_2d.py
@@ -160,9 +160,7 @@ def test_elastic_automated_adjoint_controls(
         # before anything selects controls within it.
         wave.initialize_physical_parameters()
         wave.set_physical_parameterization(parameterization)
-    wave.enable_automated_adjoint()
-    if control_parameters is not None:
-        wave.automated_adjoint.set_control_parameters(control_parameters)
+    wave.enable_automated_adjoint(control_parameters=control_parameters)
 
     try:
         wave.forward_solve()

--- a/tests/on_one_core/test_elastic_auto_adj_2d.py
+++ b/tests/on_one_core/test_elastic_auto_adj_2d.py
@@ -140,9 +140,9 @@ def test_elastic_automated_adjoint_controls(
         input_mesh_parameters={"edge_length": 0.05, "periodic": True},
     )
     wave.real_shot_record = exact_receiver_data
-    wave.enable_automated_adjoint(
-        control_parameters=control_parameters,
-    )
+    wave.enable_automated_adjoint()
+    if control_parameters is not None:
+        wave.automated_adjoint.set_control_parameters(control_parameters)
 
     try:
         wave.forward_solve()

--- a/tests/on_one_core/test_elastic_auto_adj_2d.py
+++ b/tests/on_one_core/test_elastic_auto_adj_2d.py
@@ -92,15 +92,22 @@ def exact_receiver_data():
     return wave.forward_solution_receivers
 
 
+LAME = spyro.ElasticMaterialParameterization.LAME
+VELOCITY = spyro.ElasticMaterialParameterization.VELOCITY
+
+# guess material, parameterization to write the equation in, controls to
+# select within it, controls expected on the adjoint.
 CASES = [
     pytest.param(
         LAME_MATERIAL,
+        None,
         None,
         (Parameter.DENSITY, Parameter.LAMBDA, Parameter.MU),
         id="lame-default",
     ),
     pytest.param(
         VELOCITY_MATERIAL,
+        None,
         None,
         (
             Parameter.DENSITY,
@@ -111,35 +118,48 @@ CASES = [
     ),
     pytest.param(
         LAME_MATERIAL,
+        VELOCITY,
         {Parameter.S_WAVE_VELOCITY},
         (Parameter.S_WAVE_VELOCITY,),
-        id="lame-to-single-s-velocity",
+        id="lame-model-rewritten-in-velocity",
     ),
     pytest.param(
         VELOCITY_MATERIAL,
+        LAME,
         {Parameter.LAMBDA, Parameter.MU},
         (Parameter.LAMBDA, Parameter.MU),
-        id="velocity-to-lame-subset",
+        id="velocity-model-rewritten-in-lame",
     ),
 ]
 
 
 @pytest.mark.parametrize(
-    ("guess_material", "control_parameters", "expected_parameters"),
+    (
+        "guess_material",
+        "parameterization",
+        "control_parameters",
+        "expected_parameters",
+    ),
     CASES,
 )
 def test_elastic_automated_adjoint_controls(
     exact_receiver_data,
     guess_material,
+    parameterization,
     control_parameters,
     expected_parameters,
 ):
-    """Taylor-test full, subset, and cross-family elastic controls."""
+    """Taylor-test full and subset controls, in either parameterization."""
     wave = spyro.IsotropicWave(make_dictionary(guess_material))
     wave.set_mesh(
         input_mesh_parameters={"edge_length": 0.05, "periodic": True},
     )
     wave.real_shot_record = exact_receiver_data
+    if parameterization is not None:
+        # Which family the equation is written in is decided on the wave,
+        # before anything selects controls within it.
+        wave.initialize_physical_parameters()
+        wave.set_physical_parameterization(parameterization)
     wave.enable_automated_adjoint()
     if control_parameters is not None:
         wave.automated_adjoint.set_control_parameters(control_parameters)

--- a/tests/on_one_core/test_elastic_auto_adj_2d.py
+++ b/tests/on_one_core/test_elastic_auto_adj_2d.py
@@ -156,7 +156,7 @@ def test_elastic_automated_adjoint_controls(
     )
     wave.real_shot_record = exact_receiver_data
     if parameterization is not None:
-        # Which family the equation is written in is decided on the wave,
+        # Which parameters the equation is solved in terms of is decided
         # before anything selects controls within it.
         wave.initialize_physical_parameters()
         wave.set_physical_parameterization(parameterization)

--- a/tests/on_one_core/test_elastic_auto_adj_2d.py
+++ b/tests/on_one_core/test_elastic_auto_adj_2d.py
@@ -1,0 +1,185 @@
+"""Taylor tests for selectable isotropic-elastic material controls."""
+
+import firedrake as fire
+import numpy as np
+from pyadjoint import AdjFloat, Tape
+import pytest
+
+import spyro
+
+
+pytestmark = [pytest.mark.newer_firedrake, pytest.mark.slow]
+
+Parameter = spyro.ElasticMaterialParameter
+LAME_MATERIAL = {"density": 0.12, "lambda": 0.20, "mu": 0.08}
+VELOCITY_MATERIAL = {
+    "density": 0.12,
+    "p_wave_velocity": np.sqrt(3.0),
+    "s_wave_velocity": np.sqrt(2.0 / 3.0),
+}
+
+
+def make_dictionary(material_parameters):
+    """Build a compact two-dimensional elastic model.
+
+    Parameters
+    ----------
+    material_parameters : dict
+        Complete Lame or velocity material parameterization.
+
+    Returns
+    -------
+    dict
+        Spyro model dictionary.
+    """
+    return {
+        "options": {
+            "cell_type": "T",
+            "variant": "lumped",
+            "degree": 4,
+            "dimension": 2,
+        },
+        "parallelism": {"type": "automatic"},
+        "mesh": {
+            "length_z": 1.0,
+            "length_x": 1.0,
+            "length_y": 0.0,
+            "mesh_file": None,
+            "mesh_type": "firedrake_mesh",
+        },
+        "acquisition": {
+            "source_type": "ricker",
+            "source_locations": [(-0.1, 0.5)],
+            "frequency": 5.0,
+            "delay": 1.5,
+            "delay_type": "multiples_of_minimum",
+            "amplitude": np.array([0.0, 1.0]),
+            "receiver_locations": spyro.create_transect(
+                (-0.8, 0.2), (-0.8, 0.8), 10,
+            ),
+        },
+        "time_axis": {
+            "initial_time": 0.0,
+            "final_time": 0.8,
+            "dt": 0.001,
+            "output_frequency": 100,
+            "gradient_sampling_frequency": 1,
+        },
+        "visualization": {
+            "forward_output": False,
+            "gradient_output": False,
+            "adjoint_output": False,
+            "debug_output": False,
+        },
+        "synthetic_data": {
+            "type": "object",
+            **material_parameters,
+            "real_velocity_file": None,
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def exact_receiver_data():
+    """Compute one observed record shared by all parameterizations."""
+    wave = spyro.IsotropicWave(
+        make_dictionary({"density": 0.1, "lambda": 0.025, "mu": 0.1}),
+    )
+    wave.set_mesh(
+        input_mesh_parameters={"edge_length": 0.1, "periodic": True},
+    )
+    wave.forward_solve()
+    return wave.forward_solution_receivers
+
+
+CASES = [
+    pytest.param(
+        LAME_MATERIAL,
+        None,
+        (Parameter.DENSITY, Parameter.LAMBDA, Parameter.MU),
+        id="lame-default",
+    ),
+    pytest.param(
+        VELOCITY_MATERIAL,
+        None,
+        (
+            Parameter.DENSITY,
+            Parameter.P_WAVE_VELOCITY,
+            Parameter.S_WAVE_VELOCITY,
+        ),
+        id="velocity-default",
+    ),
+    pytest.param(
+        LAME_MATERIAL,
+        {Parameter.S_WAVE_VELOCITY},
+        (Parameter.S_WAVE_VELOCITY,),
+        id="lame-to-single-s-velocity",
+    ),
+    pytest.param(
+        VELOCITY_MATERIAL,
+        {Parameter.LAMBDA, Parameter.MU},
+        (Parameter.LAMBDA, Parameter.MU),
+        id="velocity-to-lame-subset",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("guess_material", "control_parameters", "expected_parameters"),
+    CASES,
+)
+def test_elastic_automated_adjoint_controls(
+    exact_receiver_data,
+    guess_material,
+    control_parameters,
+    expected_parameters,
+):
+    """Taylor-test full, subset, and cross-family elastic controls."""
+    wave = spyro.IsotropicWave(make_dictionary(guess_material))
+    wave.set_mesh(
+        input_mesh_parameters={"edge_length": 0.05, "periodic": True},
+    )
+    wave.real_shot_record = exact_receiver_data
+    wave.enable_automated_adjoint(
+        control_parameters=control_parameters,
+    )
+
+    try:
+        wave.forward_solve()
+
+        assert isinstance(wave.automated_adjoint._tape, Tape)
+        assert isinstance(wave.functional_value, AdjFloat)
+        assert tuple(wave.automated_adjoint.control_parameter_names) == (
+            expected_parameters
+        )
+
+        gradients = wave.gradient_solve()
+        assert tuple(gradients) == expected_parameters
+        assert all(
+            isinstance(gradient, fire.Function)
+            for gradient in gradients.values()
+        )
+
+        rng = np.random.default_rng(42)
+        directions = [
+            fire.Function(
+                control.function_space(),
+                val=control.dat.data_ro * rng.random(control.dat.data_ro.shape),
+            )
+            for control in wave.automated_adjoint.controls
+        ]
+        convergence_rate = wave.automated_adjoint.verify_gradient(
+            wave.automated_adjoint.controls,
+            direction=directions,
+            dJdm=gradients,
+        )
+        assert convergence_rate > 1.9, (
+            "Elastic Taylor convergence rate %.4f < 1.90."
+            % convergence_rate
+        )
+    finally:
+        wave.automated_adjoint.clear_tape()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/on_one_core/test_functional_computations.py
+++ b/tests/on_one_core/test_functional_computations.py
@@ -2,10 +2,16 @@ from copy import deepcopy
 from types import SimpleNamespace
 
 import numpy as np
+from pyadjoint import AdjFloat
+import pytest
 
 from spyro.solvers.acoustic_wave import AcousticWave
+from spyro.solvers.automatic_differentiation_solver import AutomatedAdjoint
 from spyro.solvers.wave import Wave
-from spyro.utils.typing import FunctionalEvaluationMode
+from spyro.utils import get_real_shot_record
+from spyro.utils.typing import (ElasticMaterialParameter,
+                                FunctionalEvaluationMode, RieszMapType,
+                                WaveType)
 
 
 class DummyWave(Wave):
@@ -87,6 +93,98 @@ def test_compute_functional_accepts_after_solve_mode():
 
     wave.functional_evaluation_mode = FunctionalEvaluationMode.AFTER_SOLVE
     assert wave.functional_evaluation_mode == FunctionalEvaluationMode.AFTER_SOLVE
+
+
+def test_real_shot_record_keeps_single_elastic_vector_record():
+    wave = SimpleNamespace(
+        real_shot_record=np.zeros((11, 4, 2)),
+        current_sources=[0],
+        wave_type=WaveType.ISOTROPIC_ELASTIC,
+    )
+
+    assert get_real_shot_record(wave) is wave.real_shot_record
+
+
+def test_real_shot_record_selects_elastic_source_axis():
+    records = np.stack((np.zeros((11, 4, 2)), np.ones((11, 4, 2))))
+    wave = SimpleNamespace(
+        real_shot_record=records,
+        current_sources=[1],
+        wave_type=WaveType.ISOTROPIC_ELASTIC,
+    )
+
+    assert np.array_equal(get_real_shot_record(wave), records[1])
+
+
+def test_automated_adjoint_stores_controls_as_a_list():
+    control = object()
+    parameter = ElasticMaterialParameter.MU
+
+    unlabeled = AutomatedAdjoint(None, control)
+    labeled = AutomatedAdjoint(None, {parameter: control})
+
+    assert unlabeled.controls == [control]
+    assert unlabeled.control_parameter_names == [None]
+    assert labeled.controls == [control]
+    assert labeled.control_parameter_names == [parameter]
+
+
+def test_automated_adjoint_rejects_empty_controls():
+    automated_adjoint = AutomatedAdjoint(None)
+
+    with pytest.raises(ValueError, match="At least one control"):
+        automated_adjoint.create_reduced_functional(functional=None)
+
+
+@pytest.mark.parametrize(
+    ("riesz_map", "derivative_method"),
+    [
+        pytest.param(RieszMapType.L2, "compute_gradient", id="L2"),
+        pytest.param(RieszMapType.l2, "compute_derivative", id="l2"),
+    ],
+)
+def test_acoustic_automated_adjoint_returns_single_derivative(
+    riesz_map,
+    derivative_method,
+):
+    wave = AcousticWave.__new__(AcousticWave)
+    derivative = object()
+    wave.functional_value = AdjFloat(1.0)
+    wave.automated_adjoint = SimpleNamespace(
+        reduced_functional=object(),
+        **{derivative_method: lambda: [derivative]},
+    )
+
+    result = wave._automated_adjoint_gradient(riesz_map=riesz_map)
+
+    assert result is derivative
+
+
+def test_verify_gradient_normalizes_one_control(monkeypatch):
+    automated_adjoint = AutomatedAdjoint(None)
+    automated_adjoint.reduced_functional = object()
+    control = object()
+    direction = object()
+    captured = {}
+
+    def fake_taylor_test(functional, controls, directions, dJdm=None):
+        captured["arguments"] = (functional, controls, directions, dJdm)
+        return 2.0
+
+    monkeypatch.setattr(
+        "spyro.solvers.automatic_differentiation_solver.taylor_test",
+        fake_taylor_test,
+    )
+
+    rate = automated_adjoint.verify_gradient(control, direction=direction)
+
+    assert rate == 2.0
+    assert captured["arguments"] == (
+        automated_adjoint.reduced_functional,
+        [control],
+        [direction],
+        None,
+    )
 
 
 def _base_functional_dictionary():

--- a/tests/on_one_core/test_functional_computations.py
+++ b/tests/on_one_core/test_functional_computations.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 from types import SimpleNamespace
 
 import numpy as np
-from pyadjoint import AdjFloat
 import pytest
 
 from spyro.solvers.acoustic_wave import AcousticWave
@@ -10,8 +9,7 @@ from spyro.solvers.automatic_differentiation_solver import AutomatedAdjoint
 from spyro.solvers.wave import Wave
 from spyro.utils import get_real_shot_record
 from spyro.utils.typing import (ElasticMaterialParameter,
-                                FunctionalEvaluationMode, RieszMapType,
-                                WaveType)
+                                FunctionalEvaluationMode, WaveType)
 
 
 class DummyWave(Wave):
@@ -96,6 +94,7 @@ def test_compute_functional_accepts_after_solve_mode():
 
 
 def test_real_shot_record_keeps_single_elastic_vector_record():
+    """One elastic shot has three axes and must not be split by source."""
     wave = SimpleNamespace(
         real_shot_record=np.zeros((11, 4, 2)),
         current_sources=[0],
@@ -106,6 +105,7 @@ def test_real_shot_record_keeps_single_elastic_vector_record():
 
 
 def test_real_shot_record_selects_elastic_source_axis():
+    """Stacked elastic shots add a leading axis, indexed by active source."""
     records = np.stack((np.zeros((11, 4, 2)), np.ones((11, 4, 2))))
     wave = SimpleNamespace(
         real_shot_record=records,
@@ -117,6 +117,7 @@ def test_real_shot_record_selects_elastic_source_axis():
 
 
 def test_automated_adjoint_stores_controls_as_a_list():
+    """Controls become ordered lists, labeled only when given by name."""
     control = object()
     parameter = ElasticMaterialParameter.MU
 
@@ -130,37 +131,15 @@ def test_automated_adjoint_stores_controls_as_a_list():
 
 
 def test_automated_adjoint_rejects_empty_controls():
+    """There is nothing to differentiate with respect to without controls."""
     automated_adjoint = AutomatedAdjoint(None)
 
     with pytest.raises(ValueError, match="At least one control"):
         automated_adjoint.create_reduced_functional(functional=None)
 
 
-@pytest.mark.parametrize(
-    ("riesz_map", "derivative_method"),
-    [
-        pytest.param(RieszMapType.L2, "compute_gradient", id="L2"),
-        pytest.param(RieszMapType.l2, "compute_derivative", id="l2"),
-    ],
-)
-def test_acoustic_automated_adjoint_returns_single_derivative(
-    riesz_map,
-    derivative_method,
-):
-    wave = AcousticWave.__new__(AcousticWave)
-    derivative = object()
-    wave.functional_value = AdjFloat(1.0)
-    wave.automated_adjoint = SimpleNamespace(
-        reduced_functional=object(),
-        **{derivative_method: lambda: [derivative]},
-    )
-
-    result = wave._automated_adjoint_gradient(riesz_map=riesz_map)
-
-    assert result is derivative
-
-
 def test_verify_gradient_normalizes_one_control(monkeypatch):
+    """A single control and direction reach pyadjoint as one-item lists."""
     automated_adjoint = AutomatedAdjoint(None)
     automated_adjoint.reduced_functional = object()
     control = object()

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -219,7 +219,7 @@ def test_elastic_parameters_stay_constants_without_a_mesh():
     assert not isinstance(wave.lmbda, fire.Function)
     assert not isinstance(wave.mu, fire.Function)
 
-    assert wave._physical_parameterization is (
+    assert wave.physical_parameterization is (
         spyro.ElasticMaterialParameterization.VELOCITY
     )
     assert set(parameters) == set(ElasticMaterialParameter)
@@ -268,7 +268,7 @@ def test_elastic_automated_adjoint_accepts_one_control():
 def test_elastic_controls_follow_the_equation_parameterization():
     """Changing the family is the equation's decision, made before selecting."""
     wave = build_elastic_wave()
-    assert wave._physical_parameterization is (
+    assert wave.physical_parameterization is (
         spyro.ElasticMaterialParameterization.VELOCITY
     )
 

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -233,7 +233,8 @@ def test_elastic_automated_adjoint_defaults_to_current_parameterization():
 def test_elastic_automated_adjoint_accepts_one_control():
     wave = build_elastic_wave()
 
-    wave.enable_automated_adjoint(
+    wave.enable_automated_adjoint()
+    wave.automated_adjoint.set_control_parameters(
         {ElasticMaterialParameter.S_WAVE_VELOCITY},
     )
 
@@ -246,7 +247,10 @@ def test_elastic_automated_adjoint_accepts_one_control():
 def test_elastic_controls_can_change_the_equation_parameterization():
     wave = build_elastic_wave()
 
-    wave.enable_automated_adjoint({ElasticMaterialParameter.LAMBDA})
+    wave.enable_automated_adjoint()
+    wave.automated_adjoint.set_control_parameters(
+        {ElasticMaterialParameter.LAMBDA},
+    )
     control = wave.automated_adjoint.controls[0]
 
     assert isinstance(wave.lmbda, fire.Function)
@@ -266,9 +270,10 @@ def test_elastic_controls_can_change_the_equation_parameterization():
 
 def test_elastic_controls_reject_mixed_parameterizations():
     wave = build_elastic_wave()
+    wave.enable_automated_adjoint()
 
     with pytest.raises(ValueError, match="subset of either"):
-        wave.enable_automated_adjoint({
+        wave.automated_adjoint.set_control_parameters({
             ElasticMaterialParameter.LAMBDA,
             ElasticMaterialParameter.S_WAVE_VELOCITY,
         })
@@ -276,9 +281,10 @@ def test_elastic_controls_reject_mixed_parameterizations():
 
 def test_elastic_controls_reject_string_names():
     wave = build_elastic_wave()
+    wave.enable_automated_adjoint()
 
     with pytest.raises(TypeError, match="ElasticMaterialParameter"):
-        wave.enable_automated_adjoint({"s_wave_velocity"})
+        wave.automated_adjoint.set_control_parameters({"s_wave_velocity"})
 
 
 # Control parameters belong to the inversion.

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -219,7 +219,7 @@ def test_elastic_parameters_stay_constants_without_a_mesh():
     assert not isinstance(wave.lmbda, fire.Function)
     assert not isinstance(wave.mu, fire.Function)
 
-    assert wave.physical_parameterization is (
+    assert wave._physical_parameterization is (
         spyro.ElasticMaterialParameterization.VELOCITY
     )
     assert set(parameters) == set(ElasticMaterialParameter)
@@ -270,7 +270,7 @@ def test_elastic_automated_adjoint_accepts_one_control():
 def test_elastic_controls_follow_the_equation_parameterization():
     """Changing the family is the equation's decision, made before selecting."""
     wave = build_elastic_wave()
-    assert wave.physical_parameterization is (
+    assert wave._physical_parameterization is (
         spyro.ElasticMaterialParameterization.VELOCITY
     )
 

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -265,9 +265,16 @@ def test_elastic_automated_adjoint_accepts_one_control():
     assert wave.automated_adjoint.controls[0] is wave.c_s
 
 
-def test_elastic_controls_can_change_the_equation_parameterization():
+def test_elastic_controls_follow_the_equation_parameterization():
+    """Changing the family is the equation's decision, made before selecting."""
     wave = build_elastic_wave()
+    assert wave._physical_parameterization is (
+        spyro.ElasticMaterialParameterization.VELOCITY
+    )
 
+    wave.set_physical_parameterization(
+        spyro.ElasticMaterialParameterization.LAME,
+    )
     wave.enable_automated_adjoint()
     wave.automated_adjoint.set_control_parameters(
         {ElasticMaterialParameter.LAMBDA},
@@ -278,8 +285,8 @@ def test_elastic_controls_can_change_the_equation_parameterization():
     assert isinstance(wave.mu, fire.Function)
     assert control is wave.lmbda
 
-    # Changing the equation over to the Lame family is a change of variables on
-    # the solver, not an edit of the model the user handed in.
+    # The change of variables is on the solver, not an edit of the model the
+    # user handed in.
     assert set(wave.input_dictionary["synthetic_data"]) >= {
         "density", "p_wave_velocity", "s_wave_velocity",
     }
@@ -287,16 +294,29 @@ def test_elastic_controls_can_change_the_equation_parameterization():
     assert "mu" not in wave.input_dictionary["synthetic_data"]
 
     # The forward solve initializes the material parameters again. It must
-    # retain the exact field registered as a pyadjoint control.
+    # retain the exact field registered as a control.
     wave.initialize_physical_parameters()
     assert wave.lmbda is control
+
+
+def test_elastic_controls_reject_the_other_family():
+    """Selecting a parameter the equation is not written in is an error."""
+    wave = build_elastic_wave()
+    wave.enable_automated_adjoint()
+
+    with pytest.raises(TypeError, match="computed from the other physical"):
+        wave.automated_adjoint.set_control_parameters(
+            {ElasticMaterialParameter.LAMBDA},
+        )
 
 
 def test_elastic_controls_reject_mixed_parameterizations():
     wave = build_elastic_wave()
     wave.enable_automated_adjoint()
 
-    with pytest.raises(ValueError, match="subset of either"):
+    # Half of this selection is in the velocity family the equation uses; the
+    # other half never can be at the same time.
+    with pytest.raises(TypeError, match="computed from the other physical"):
         wave.automated_adjoint.set_control_parameters({
             ElasticMaterialParameter.LAMBDA,
             ElasticMaterialParameter.S_WAVE_VELOCITY,
@@ -307,7 +327,7 @@ def test_elastic_controls_reject_string_names():
     wave = build_elastic_wave()
     wave.enable_automated_adjoint()
 
-    with pytest.raises(TypeError, match="ElasticMaterialParameter"):
+    with pytest.raises(TypeError, match="material-parameter enum members"):
         wave.automated_adjoint.set_control_parameters({"s_wave_velocity"})
 
 

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -226,6 +226,7 @@ def test_elastic_parameters_stay_constants_without_a_mesh():
 
 
 def test_elastic_automated_adjoint_defaults_to_current_parameterization():
+    """Unasked, the controls are the family in use, and survive a rebuild."""
     wave = build_elastic_wave()
 
     wave.enable_automated_adjoint()
@@ -252,6 +253,7 @@ def test_elastic_automated_adjoint_defaults_to_current_parameterization():
 
 
 def test_elastic_automated_adjoint_accepts_one_control():
+    """A subset of the family in use is a valid selection."""
     wave = build_elastic_wave()
 
     wave.enable_automated_adjoint()
@@ -311,6 +313,7 @@ def test_elastic_controls_reject_the_other_family():
 
 
 def test_elastic_controls_reject_mixed_parameterizations():
+    """No selection spans both families: one is expressions of the other."""
     wave = build_elastic_wave()
     wave.enable_automated_adjoint()
 
@@ -324,6 +327,7 @@ def test_elastic_controls_reject_mixed_parameterizations():
 
 
 def test_elastic_controls_reject_string_names():
+    """Parameters are named by enum members, not by their dictionary keys."""
     wave = build_elastic_wave()
     wave.enable_automated_adjoint()
 

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -204,23 +204,6 @@ def test_physical_parameters_are_keyed_by_material_parameter_enums():
     )
 
 
-def test_elastic_parameters_stay_constants_without_a_mesh():
-    """The model can be read before a mesh exists, without building fields."""
-    wave = spyro.IsotropicWave(dictionary=build_elastic_dictionary())
-    assert wave.mesh is None
-
-    parameters = wave.initialize_physical_parameters()
-
-    # The declared set stays as Constants: there is no space to build
-    # Functions in yet, and initialization must still be able to complete.
-    assert isinstance(wave.rho, fire.Constant)
-    assert isinstance(wave.c, fire.Constant)
-    assert isinstance(wave.c_s, fire.Constant)
-    assert not isinstance(wave.lmbda, fire.Function)
-    assert not isinstance(wave.mu, fire.Function)
-    assert set(parameters) == set(ElasticMaterialParameter)
-
-
 def test_elastic_automated_adjoint_defaults_to_current_parameterization():
     """Unasked, the controls are the set in use, and survive a rebuild."""
     wave = build_elastic_wave()
@@ -304,29 +287,6 @@ def test_elastic_controls_reject_the_other_set():
     with pytest.raises(TypeError, match="computed from the other physical"):
         wave.enable_automated_adjoint(
             control_parameters={ElasticMaterialParameter.LAMBDA},
-        )
-
-
-def test_elastic_controls_reject_mixed_parameterizations():
-    """No selection spans both sets: one is expressions of the other."""
-    wave = build_elastic_wave()
-
-    # Half of this selection is in the velocity set the equation uses; the
-    # other half never can be at the same time.
-    with pytest.raises(TypeError, match="computed from the other physical"):
-        wave.enable_automated_adjoint(control_parameters={
-            ElasticMaterialParameter.LAMBDA,
-            ElasticMaterialParameter.S_WAVE_VELOCITY,
-        })
-
-
-def test_elastic_controls_reject_string_names():
-    """Parameters are named by enum members, not by their dictionary keys."""
-    wave = build_elastic_wave()
-
-    with pytest.raises(TypeError, match="material-parameter enum members"):
-        wave.enable_automated_adjoint(
-            control_parameters={"s_wave_velocity"},
         )
 
 

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -256,9 +256,8 @@ def test_elastic_automated_adjoint_accepts_one_control():
     """A subset of the family in use is a valid selection."""
     wave = build_elastic_wave()
 
-    wave.enable_automated_adjoint()
-    wave.automated_adjoint.set_control_parameters(
-        {ElasticMaterialParameter.S_WAVE_VELOCITY},
+    wave.enable_automated_adjoint(
+        control_parameters={ElasticMaterialParameter.S_WAVE_VELOCITY},
     )
 
     assert wave.automated_adjoint.control_parameter_names == [
@@ -277,9 +276,8 @@ def test_elastic_controls_follow_the_equation_parameterization():
     wave.set_physical_parameterization(
         spyro.ElasticMaterialParameterization.LAME,
     )
-    wave.enable_automated_adjoint()
-    wave.automated_adjoint.set_control_parameters(
-        {ElasticMaterialParameter.LAMBDA},
+    wave.enable_automated_adjoint(
+        control_parameters={ElasticMaterialParameter.LAMBDA},
     )
     control = wave.automated_adjoint.controls[0]
 
@@ -304,23 +302,21 @@ def test_elastic_controls_follow_the_equation_parameterization():
 def test_elastic_controls_reject_the_other_family():
     """Selecting a parameter the equation is not written in is an error."""
     wave = build_elastic_wave()
-    wave.enable_automated_adjoint()
 
     with pytest.raises(TypeError, match="computed from the other physical"):
-        wave.automated_adjoint.set_control_parameters(
-            {ElasticMaterialParameter.LAMBDA},
+        wave.enable_automated_adjoint(
+            control_parameters={ElasticMaterialParameter.LAMBDA},
         )
 
 
 def test_elastic_controls_reject_mixed_parameterizations():
     """No selection spans both families: one is expressions of the other."""
     wave = build_elastic_wave()
-    wave.enable_automated_adjoint()
 
     # Half of this selection is in the velocity family the equation uses; the
     # other half never can be at the same time.
     with pytest.raises(TypeError, match="computed from the other physical"):
-        wave.automated_adjoint.set_control_parameters({
+        wave.enable_automated_adjoint(control_parameters={
             ElasticMaterialParameter.LAMBDA,
             ElasticMaterialParameter.S_WAVE_VELOCITY,
         })
@@ -329,10 +325,11 @@ def test_elastic_controls_reject_mixed_parameterizations():
 def test_elastic_controls_reject_string_names():
     """Parameters are named by enum members, not by their dictionary keys."""
     wave = build_elastic_wave()
-    wave.enable_automated_adjoint()
 
     with pytest.raises(TypeError, match="material-parameter enum members"):
-        wave.automated_adjoint.set_control_parameters({"s_wave_velocity"})
+        wave.enable_automated_adjoint(
+            control_parameters={"s_wave_velocity"},
+        )
 
 
 # Control parameters belong to the inversion.

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -256,14 +256,17 @@ def test_elastic_controls_can_change_the_equation_parameterization():
     assert isinstance(wave.lmbda, fire.Function)
     assert isinstance(wave.mu, fire.Function)
     assert control is wave.lmbda
-    assert set(wave.input_dictionary["synthetic_data"]) >= {
-        "density", "lambda", "mu",
-    }
-    assert "p_wave_velocity" not in wave.input_dictionary["synthetic_data"]
-    assert "s_wave_velocity" not in wave.input_dictionary["synthetic_data"]
 
-    # The forward solve initializes from this dictionary again. It must retain
-    # the exact field registered as a pyadjoint control.
+    # Changing the equation over to the Lame family is a change of variables on
+    # the solver, not an edit of the model the user handed in.
+    assert set(wave.input_dictionary["synthetic_data"]) >= {
+        "density", "p_wave_velocity", "s_wave_velocity",
+    }
+    assert "lambda" not in wave.input_dictionary["synthetic_data"]
+    assert "mu" not in wave.input_dictionary["synthetic_data"]
+
+    # The forward solve initializes the material parameters again. It must
+    # retain the exact field registered as a pyadjoint control.
     wave.initialize_physical_parameters()
     assert wave.lmbda is control
 

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -218,10 +218,6 @@ def test_elastic_parameters_stay_constants_without_a_mesh():
     assert isinstance(wave.c_s, fire.Constant)
     assert not isinstance(wave.lmbda, fire.Function)
     assert not isinstance(wave.mu, fire.Function)
-
-    assert wave._physical_parameterization is (
-        spyro.ElasticMaterialParameterization.VELOCITY
-    )
     assert set(parameters) == set(ElasticMaterialParameter)
 
 
@@ -269,9 +265,11 @@ def test_elastic_automated_adjoint_accepts_one_control():
 def test_elastic_controls_follow_the_equation_parameterization():
     """Changing the family is the equation's decision, made before selecting."""
     wave = build_elastic_wave()
-    assert wave._physical_parameterization is (
-        spyro.ElasticMaterialParameterization.VELOCITY
-    )
+    assert set(wave.physical_parameters.select()) == {
+        ElasticMaterialParameter.DENSITY,
+        ElasticMaterialParameter.P_WAVE_VELOCITY,
+        ElasticMaterialParameter.S_WAVE_VELOCITY,
+    }
 
     wave.set_physical_parameterization(
         spyro.ElasticMaterialParameterization.LAME,

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -204,6 +204,27 @@ def test_physical_parameters_are_keyed_by_material_parameter_enums():
     )
 
 
+def test_elastic_parameters_stay_constants_without_a_mesh():
+    """The model can be read before a mesh exists, without building fields."""
+    wave = spyro.IsotropicWave(dictionary=build_elastic_dictionary())
+    assert wave.mesh is None
+
+    parameters = wave.initialize_physical_parameters()
+
+    # The declared family stays as Constants: there is no space to build
+    # Functions in yet, and initialization must still be able to complete.
+    assert isinstance(wave.rho, fire.Constant)
+    assert isinstance(wave.c, fire.Constant)
+    assert isinstance(wave.c_s, fire.Constant)
+    assert not isinstance(wave.lmbda, fire.Function)
+    assert not isinstance(wave.mu, fire.Function)
+
+    assert wave._physical_parameterization is (
+        spyro.ElasticMaterialParameterization.VELOCITY
+    )
+    assert set(parameters) == set(ElasticMaterialParameter)
+
+
 def test_elastic_automated_adjoint_defaults_to_current_parameterization():
     wave = build_elastic_wave()
 

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -48,7 +48,13 @@ def build_acoustic_dictionary():
     }
 
 
-def build_elastic_dictionary():
+def build_elastic_dictionary(material_parameters=None):
+    if material_parameters is None:
+        material_parameters = {
+            "density": 1.0,
+            "p_wave_velocity": 2.5,
+            "s_wave_velocity": 1.0,
+        }
     return {
         "options": {
             "cell_type": "T",
@@ -75,9 +81,7 @@ def build_elastic_dictionary():
         },
         "synthetic_data": {
             "type": "object",
-            "density": 1.0,
-            "p_wave_velocity": 2.5,
-            "s_wave_velocity": 1.0,
+            **material_parameters,
             "real_velocity_file": None,
         },
         "time_axis": {
@@ -198,6 +202,83 @@ def test_physical_parameters_are_keyed_by_material_parameter_enums():
         wave.physical_parameters[spyro.ElasticMaterialParameter.DENSITY]
         is wave.rho
     )
+
+
+def test_elastic_automated_adjoint_defaults_to_current_parameterization():
+    wave = build_elastic_wave()
+
+    wave.enable_automated_adjoint()
+
+    assert wave.automated_adjoint.control_parameter_names == [
+        ElasticMaterialParameter.DENSITY,
+        ElasticMaterialParameter.P_WAVE_VELOCITY,
+        ElasticMaterialParameter.S_WAVE_VELOCITY,
+    ]
+    assert all(
+        control is field
+        for control, field in zip(
+            wave.automated_adjoint.controls,
+            (wave.rho, wave.c, wave.c_s),
+        )
+    )
+
+    controls = list(wave.automated_adjoint.controls)
+    wave.initialize_physical_parameters()
+    assert all(
+        control is field
+        for control, field in zip(controls, (wave.rho, wave.c, wave.c_s))
+    )
+
+
+def test_elastic_automated_adjoint_accepts_one_control():
+    wave = build_elastic_wave()
+
+    wave.enable_automated_adjoint(
+        {ElasticMaterialParameter.S_WAVE_VELOCITY},
+    )
+
+    assert wave.automated_adjoint.control_parameter_names == [
+        ElasticMaterialParameter.S_WAVE_VELOCITY,
+    ]
+    assert wave.automated_adjoint.controls[0] is wave.c_s
+
+
+def test_elastic_controls_can_change_the_equation_parameterization():
+    wave = build_elastic_wave()
+
+    wave.enable_automated_adjoint({ElasticMaterialParameter.LAMBDA})
+    control = wave.automated_adjoint.controls[0]
+
+    assert isinstance(wave.lmbda, fire.Function)
+    assert isinstance(wave.mu, fire.Function)
+    assert control is wave.lmbda
+    assert set(wave.input_dictionary["synthetic_data"]) >= {
+        "density", "lambda", "mu",
+    }
+    assert "p_wave_velocity" not in wave.input_dictionary["synthetic_data"]
+    assert "s_wave_velocity" not in wave.input_dictionary["synthetic_data"]
+
+    # The forward solve initializes from this dictionary again. It must retain
+    # the exact field registered as a pyadjoint control.
+    wave.initialize_physical_parameters()
+    assert wave.lmbda is control
+
+
+def test_elastic_controls_reject_mixed_parameterizations():
+    wave = build_elastic_wave()
+
+    with pytest.raises(ValueError, match="subset of either"):
+        wave.enable_automated_adjoint({
+            ElasticMaterialParameter.LAMBDA,
+            ElasticMaterialParameter.S_WAVE_VELOCITY,
+        })
+
+
+def test_elastic_controls_reject_string_names():
+    wave = build_elastic_wave()
+
+    with pytest.raises(TypeError, match="ElasticMaterialParameter"):
+        wave.enable_automated_adjoint({"s_wave_velocity"})
 
 
 # Control parameters belong to the inversion.

--- a/tests/on_one_core/test_fwi_controls.py
+++ b/tests/on_one_core/test_fwi_controls.py
@@ -211,7 +211,7 @@ def test_elastic_parameters_stay_constants_without_a_mesh():
 
     parameters = wave.initialize_physical_parameters()
 
-    # The declared family stays as Constants: there is no space to build
+    # The declared set stays as Constants: there is no space to build
     # Functions in yet, and initialization must still be able to complete.
     assert isinstance(wave.rho, fire.Constant)
     assert isinstance(wave.c, fire.Constant)
@@ -222,7 +222,7 @@ def test_elastic_parameters_stay_constants_without_a_mesh():
 
 
 def test_elastic_automated_adjoint_defaults_to_current_parameterization():
-    """Unasked, the controls are the family in use, and survive a rebuild."""
+    """Unasked, the controls are the set in use, and survive a rebuild."""
     wave = build_elastic_wave()
 
     wave.enable_automated_adjoint()
@@ -249,7 +249,7 @@ def test_elastic_automated_adjoint_defaults_to_current_parameterization():
 
 
 def test_elastic_automated_adjoint_accepts_one_control():
-    """A subset of the family in use is a valid selection."""
+    """A subset of the set in use is a valid selection."""
     wave = build_elastic_wave()
 
     wave.enable_automated_adjoint(
@@ -263,7 +263,7 @@ def test_elastic_automated_adjoint_accepts_one_control():
 
 
 def test_elastic_controls_follow_the_equation_parameterization():
-    """Changing the family is the equation's decision, made before selecting."""
+    """Changing the set is the equation's decision, made before selecting."""
     wave = build_elastic_wave()
     assert set(wave.physical_parameters.select()) == {
         ElasticMaterialParameter.DENSITY,
@@ -297,7 +297,7 @@ def test_elastic_controls_follow_the_equation_parameterization():
     assert wave.lmbda is control
 
 
-def test_elastic_controls_reject_the_other_family():
+def test_elastic_controls_reject_the_other_set():
     """Selecting a parameter the equation is not written in is an error."""
     wave = build_elastic_wave()
 
@@ -308,10 +308,10 @@ def test_elastic_controls_reject_the_other_family():
 
 
 def test_elastic_controls_reject_mixed_parameterizations():
-    """No selection spans both families: one is expressions of the other."""
+    """No selection spans both sets: one is expressions of the other."""
     wave = build_elastic_wave()
 
-    # Half of this selection is in the velocity family the equation uses; the
+    # Half of this selection is in the velocity set the equation uses; the
     # other half never can be at the same time.
     with pytest.raises(TypeError, match="computed from the other physical"):
         wave.enable_automated_adjoint(control_parameters={

--- a/tests/parallel/test_elastic_sources_parallel.py
+++ b/tests/parallel/test_elastic_sources_parallel.py
@@ -1,0 +1,160 @@
+"""Elastic automated-adjoint test under source parallelism.
+
+Run with two MPI ranks::
+
+    mpiexec -n 2 pytest tests/parallel/test_elastic_sources_parallel.py
+"""
+
+import firedrake as fire
+import firedrake.adjoint as fire_ad
+import numpy as np
+from pyadjoint import AdjFloat, Tape
+import pytest
+
+import spyro
+
+
+Parameter = spyro.ElasticMaterialParameter
+EXACT_MATERIAL = {"density": 0.1, "lambda": 0.025, "mu": 0.1}
+GUESS_MATERIAL = {"density": 0.12, "lambda": 0.20, "mu": 0.08}
+
+
+def make_dictionary(material_parameters):
+    """Build a two-source elastic problem for two MPI ranks.
+
+    Parameters
+    ----------
+    material_parameters : dict
+        Complete Lame material parameterization.
+
+    Returns
+    -------
+    dict
+        Spyro model dictionary.
+    """
+    return {
+        "options": {
+            "cell_type": "T",
+            "variant": "lumped",
+            "degree": 4,
+            "dimension": 2,
+        },
+        "parallelism": {"type": "automatic"},
+        "mesh": {
+            "length_z": 1.0,
+            "length_x": 1.0,
+            "length_y": 0.0,
+            "mesh_file": None,
+            "mesh_type": "firedrake_mesh",
+        },
+        "acquisition": {
+            "source_type": "ricker",
+            "source_locations": [(-0.1, 0.3), (-0.1, 0.7)],
+            "frequency": 10.0,
+            "delay": 1.5,
+            "delay_type": "multiples_of_minimum",
+            "amplitude": np.array([0.0, 1.0]),
+            "receiver_locations": spyro.create_transect(
+                (-0.2, 0.2), (-0.2, 0.8), 4,
+            ),
+        },
+        "time_axis": {
+            "initial_time": 0.0,
+            "final_time": 0.8,
+            "dt": 0.002,
+            "output_frequency": 100,
+            "gradient_sampling_frequency": 1,
+        },
+        "visualization": {
+            "forward_output": False,
+            "gradient_output": False,
+            "adjoint_output": False,
+            "debug_output": False,
+        },
+        "synthetic_data": {
+            "type": "object",
+            **material_parameters,
+            "real_velocity_file": None,
+        },
+    }
+
+
+@pytest.fixture(scope="module")
+def exact_wave():
+    """Compute one observed elastic shot on each ensemble member."""
+    wave = spyro.IsotropicWave(make_dictionary(EXACT_MATERIAL))
+    wave.set_mesh(
+        input_mesh_parameters={"edge_length": 0.1, "periodic": True},
+    )
+    wave.forward_solve()
+    return wave
+
+
+@pytest.mark.newer_firedrake
+@pytest.mark.slow
+@pytest.mark.parallel(2)
+def test_elastic_gradient_sources_parallel(exact_wave):
+    """Taylor-test the ensemble-summed multi-control elastic gradient."""
+    wave = spyro.IsotropicWave(make_dictionary(GUESS_MATERIAL))
+    wave.set_mesh(
+        input_mesh_parameters={"edge_length": 0.1, "periodic": True},
+    )
+    wave.real_shot_record = exact_wave.forward_solution_receivers.copy()
+    wave.enable_automated_adjoint()
+
+    try:
+        wave.forward_solve()
+
+        assert wave.comm.ensemble_comm.size == 2
+        assert wave.comm.comm.size == 1
+        assert wave.current_sources == wave.shot_ids_per_propagation[
+            wave.comm.ensemble_comm.rank
+        ]
+        number_of_steps = int(wave.final_time / wave.dt) + 1
+        assert wave.forward_solution_receivers.shape == (
+            number_of_steps, 4, wave.dimension,
+        )
+        assert isinstance(wave.automated_adjoint._tape, Tape)
+        assert isinstance(wave.functional_value, AdjFloat)
+
+        reduced_functional = wave.automated_adjoint.create_reduced_functional(
+            wave.functional_value,
+        )
+        assert isinstance(
+            reduced_functional, fire_ad.EnsembleReducedFunctional,
+        )
+
+        gradients = wave.gradient_solve()
+        assert tuple(gradients) == (
+            Parameter.DENSITY,
+            Parameter.LAMBDA,
+            Parameter.MU,
+        )
+        for gradient in gradients.values():
+            norms = wave.comm.ensemble_comm.allgather(fire.norm(gradient))
+            assert np.allclose(norms, norms[0])
+
+        common_shape = 1.0 + 0.1 * fire.sin(2.0 * wave.mesh_x) * fire.cos(
+            2.0 * wave.mesh_z,
+        )
+        directions = [
+            fire.Function(control.function_space()).interpolate(
+                control * common_shape,
+            )
+            for control in wave.automated_adjoint.controls
+        ]
+        convergence_rate = wave.automated_adjoint.verify_gradient(
+            wave.automated_adjoint.controls,
+            direction=directions,
+            dJdm=gradients,
+        )
+        assert convergence_rate > 1.9, (
+            "Parallel elastic Taylor convergence rate %.4f < 1.90."
+            % convergence_rate
+        )
+    finally:
+        wave.automated_adjoint.clear_tape()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/parallel/test_gradient_auto_adjoint.py
+++ b/tests/parallel/test_gradient_auto_adjoint.py
@@ -182,8 +182,9 @@ def test_gradient_auto_adjoint_parallel():
 
     # The ensemble-summed gradient is a Function in the control space.
     dJ = Wave_obj_guess.automated_adjoint.compute_gradient()
-    assert isinstance(dJ, fire.Function)
-    assert dJ.dat.data.shape == Wave_obj_guess.c.dat.data.shape
+    assert len(dJ) == 1
+    assert isinstance(dJ[0], fire.Function)
+    assert dJ[0].dat.data.shape == Wave_obj_guess.c.dat.data.shape
 
     # Deterministic perturbation direction, identical on both ensemble members.
     direction = build_direction(Wave_obj_guess)

--- a/tests/parallel/test_gradient_auto_adjoint.py
+++ b/tests/parallel/test_gradient_auto_adjoint.py
@@ -182,9 +182,8 @@ def test_gradient_auto_adjoint_parallel():
 
     # The ensemble-summed gradient is a Function in the control space.
     dJ = Wave_obj_guess.automated_adjoint.compute_gradient()
-    assert len(dJ) == 1
-    assert isinstance(dJ[0], fire.Function)
-    assert dJ[0].dat.data.shape == Wave_obj_guess.c.dat.data.shape
+    assert isinstance(dJ, fire.Function)
+    assert dJ.dat.data.shape == Wave_obj_guess.c.dat.data.shape
 
     # Deterministic perturbation direction, identical on both ensemble members.
     direction = build_direction(Wave_obj_guess)


### PR DESCRIPTION
Extends the automated adjoint (pyadjoint, via `firedrake.adjoint`) from the
acoustic solver to the isotropic elastic one, with selectable material
controls.

### What this adds

**Multiple controls.** `AutomatedAdjoint` held exactly one control, fixed to
`wave.c`. It now holds an ordered list, builds the reduced functional from a
list of `Control`s, and returns one derivative per control. A single control
still returns a bare `Function`, following pyadjoint's own convention, so the
acoustic API is unchanged.

**Selectable parameters.** `enable_automated_adjoint(control_parameters=...)`
names the parameters to differentiate with respect to. They are resolved
before any adjoint state exists, so an invalid selection fails early rather
than half-way through. Passing nothing selects everything the equation
offers.

**Change of variables.** An isotropic elastic medium has five named material
parameters and three degrees of freedom. All five are read regardless: the
variational form is written in density and the Lame parameters, while the
absorbing boundary conditions and the stable timestep estimate are written in
the two wave speeds.

What the choice decides is which three carry the data:

- declaring `{density, lambda, mu}` computes
  `p_wave_velocity = sqrt((lambda + 2*mu)/density)` and
  `s_wave_velocity = sqrt(mu/density)`;
- declaring `{density, p_wave_velocity, s_wave_velocity}` computes
  `mu = density*s_wave_velocity**2` and
  `lambda = density*p_wave_velocity**2 - 2*mu`.

The three that carry the data are `Function` fields; the other two are UFL
expressions of them. This is not cosmetic: the variational form embeds those
expressions, so the assembled problem depends symbolically on whichever
fields are the source, and the chain rule reaches only those. Differentiating
with respect to `p_wave_velocity` requires it to be a field, because a
computed expression has no degrees of freedom to perturb — and when the Lame
parameters are the fields, `p_wave_velocity` does not appear in the form at
all.

`Wave.set_physical_parameterization()` moves the source from one set to the
other, so an inversion is not tied to the parameters its model happens to be
stored in. Which set is used changes the conditioning of the problem and the
cross-talk between parameters, so it is worth choosing deliberately. It is
chosen once, before the adjoint is enabled.

**A fix in `get_real_shot_record`.** Elastic records are
`(n_timesteps, n_receivers, dimension)`. Rank was compared against a
constant, so one elastic shot was indistinguishable from several acoustic
ones. It now compares against the rank the wave type implies. This only
manifests with multiple shots, which is why the parallel test covers it.

### Design notes

`AutomatedAdjoint` gets everything it needs about the forward problem from
the tape that the forward solve recorded — which is what it differentiates.
What it does not have is a reference to the wave equation, or any branch on
wave type, parameterisation or medium: it receives the controls, already
resolved, and the ensemble to sum over, and works from the recording.

Resolving names to fields is `PhysicalParameters.select()`, since it is
entirely about the container's contents: a name is selectable exactly when it
is carried by a field rather than computed from the others.

Elastic material parameters are now built once rather than on every forward
solve. The acoustic solver already behaved this way. Rebuilding replaced the
objects the adjoint is posed with respect to, and would reset an inversion's
current iterate to the model's initial values. Replacing the model clears the
parameters, which is what allows them to be built again.

### Tests

- `tests/on_one_core/test_elastic_auto_adj_2d.py` — Taylor tests over four
  cases: both parameterizations with every parameter as a control, a
  single-parameter subset, and a two-parameter subset after a change of
  variables. Convergence rate above 1.9 in all four.
- `tests/parallel/test_elastic_sources_parallel.py` — the ensemble-summed
  multi-control gradient under source parallelism, checking each control's
  gradient is identical across ensemble members. Added to the CI job that
  runs the parallel inversion tests.
- Unit tests for control normalization, shot-record ranks, and the rejection
  of parameters the equation carries as expressions.