### PR TITLE
Marking tests as slow

### DIFF
--- a/tests/on_one_core/test_modal_analytical_solver.py
+++ b/tests/on_one_core/test_modal_analytical_solver.py
@@ -335,7 +335,8 @@ def run_modal(wave, fitting_c, exp_value, n_root=1):
     param("T", 3, 6.0, True, marks=mark.slow),
     param("T", 3, 2.4, False, marks=mark.slow),
     param("T", 3, None, False, marks=mark.slow),
-    param("Q", 3, None, False, marks=mark.slow)])
+    param("Q", 3, None, False, marks=mark.slow),
+    param("Q", 3, None, True, marks=mark.slow)])
 def test_modal(wave_instance, element_geometry, dimension, degree_layer, homogeneous):
     """Testing modal solvers for 2D and 3D case in Fig. 8 of Salas et al (2022).
 

--- a/tests/on_one_core/test_modal_solvers.py
+++ b/tests/on_one_core/test_modal_solvers.py
@@ -289,6 +289,7 @@ def run_modal(wave, modal_solver_lst, fitting_c, exp_value, n_root=1):
     ("T", 2, None, True),
     ("T", 2, 2.0, False),
     ("T", 2, None, False),
+    param("T", 2, 2.5, True, marks=mark.slow),
     param("T", 3, 6.0, True, marks=mark.slow),
     param("T", 3, None, True, marks=mark.slow),
     param("T", 3, 2.4, False, marks=mark.slow),


### PR DESCRIPTION
Just keeping up with the newer tests that consistently take up more than 120 seconds in the runners and marking them as slow.