### PR TITLE
Fix failing MPI profilers on some systems

### DIFF
--- a/makefiles/profiling.mk
+++ b/makefiles/profiling.mk
@@ -142,11 +142,11 @@ profile-memory-mpi:
 	@rm -f $(PROFILERS_DIR)/mprofile_*.dat 2>/dev/null || true
 	@echo "Running memory profile..."
 	@if [ -n "$(FUNCTION)" ]; then \
-		echo "Running: mprof run -o $(PROFILE_DAT) -- sh -c '$(MPI_CMD) python3 -m memory_profiler -m pytest $(FILE)::$(FUNCTION) -s'"; \
-		mprof run -o $(PROFILE_DAT) -- sh -c '$(MPI_CMD) python3 -m memory_profiler -m pytest $(FILE)::$(FUNCTION) -s'; \
+		echo "Running: mprof run -o $(PROFILE_DAT) sh -c '$(MPI_CMD) python3 -m memory_profiler -m pytest $(FILE)::$(FUNCTION) -s'"; \
+		mprof run -o $(PROFILE_DAT) sh -c '$(MPI_CMD) python3 -m memory_profiler -m pytest $(FILE)::$(FUNCTION) -s'; \
 	else \
-		echo "Running: mprof run -o $(PROFILE_DAT) -- sh -c '$(MPI_CMD) python3 -m memory_profiler $(FILE)'"; \
-		mprof run -o $(PROFILE_DAT) -- sh -c '$(MPI_CMD) python3 -m memory_profiler $(FILE)'; \
+		echo "Running: mprof run -o $(PROFILE_DAT) sh -c '$(MPI_CMD) python3 -m memory_profiler $(FILE)'"; \
+		mprof run -o $(PROFILE_DAT) sh -c '$(MPI_CMD) python3 -m memory_profiler $(FILE)'; \
 	fi
 	@echo ""
 	@echo "Generating memory plot..."


### PR DESCRIPTION
Fixes the mpi profilers. For example, to profile a file with mpi and 6 cores, focusing on either memory, cpu runtime or all use any of the commands below:
```
make profile-memory-mpi FILE=folder/filename.py MPI_NPROCS=6
make profile-cpu-mpi FILE=folder/filename.py MPI_NPROCS=6
make profile-all-mpi FILE=folder/filename.py MPI_NPROCS=6
```
I didn't change the regular non-mpi profilers, which continue to be the same command but without the mpi (i.e. `make profile-cpu FILE=folder/filename.py `)