### PR TITLE
Refactor acoustic and elastic weak-form builders

### DIFF
--- a/spyro/solvers/acoustic_solver_construction_no_pml.py
+++ b/spyro/solvers/acoustic_solver_construction_no_pml.py
@@ -1,21 +1,54 @@
-"""Constructs Firedrake solver for the acoustic wave with typical BCs, 
-NRBCs or HABCs."""
+"""Constructs Firedrake solver for the acoustic wave with BCs, NRBCs, HABCs."""
 
 import firedrake as fire
 from firedrake import ds, dx, dot, grad, sqrt
 from ..utils.typing import AbsorbingBCsType
 
 
+def velocity_fluid(c=None, K=None, rho_fluid=None, default=None):
+    """Resolve the acoustic wave velocity.
+
+    Uses either an explicity value or the fluid bulk modulus and density.
+
+    Parameters
+    ----------
+    c : `firedrake.Constant` or UFL expression, optional
+        Fluid wave speed. Mutually exclusive with `K`/`rho_fluid`.
+    K : `firedrake.Constant` or `firedrake.Function`, optional
+        Fluid bulk modulus. Must be given together with `rho_fluid`.
+    rho_fluid : `firedrake.Constant` or `firedrake.Function`, optional
+        Fluid density. Must be given together with `K`.
+    default : `firedrake.Constant` or UFL expression, optional.
+        Value to return when neither `c` nor `K`/`rho_fluid` are given.
+
+    Returns
+    -------
+    c : UFL expression
+        The resolved wave velocity.
+
+    Raises
+    ------
+    ValueError
+        If `c` is given together with `K` or `rho_flui`, or if
+        only one of `K`/`rho_fluid` is given.
+    """
+    if c is not None and (K is not None or rho_fluid is not None):
+        raise ValueError(
+            "Ambiguous formulation. Insert 'bulk_modulus' and 'density_fluid' "
+            "or just 'velocity_fluid'."
+        )
+    if c is None:
+        if K is not None and rho_fluid is not None:
+            c = sqrt(K / rho_fluid)
+        elif K is not None or rho_fluid is not None:
+            raise ValueError("Insert both values 'bulk_modulus' and 'density_fluid'.")
+        else:
+            c = default
+    return c
+
+
 def build_acoustic_form(
-    wave,
-    u_trial,
-    v_test,
-    u_n,
-    u_nm1,
-    quad_rule,
-    c=None,
-    K=None,
-    rho_fluid=None
+    wave, u_trial, v_test, u_n, u_nm1, quad_rule, c=None, K=None, rho_fluid=None
 ):
     """Build the weak form of the acoustic wave equation for one time step.
 
@@ -33,12 +66,9 @@ def build_acoustic_form(
         Pressure field at the previous time step.
     quad_rule : dict
         Quadrature rule for volume integration.
-    c : `firedrake.Constant` or UFL expression, optional
-        Fluid wave speed. Mutually exclusive with `K`/`rho_fluid`.
-    K : `firedrake.Constant` or `firedrake.Function`, optional
-        Fluid bulk modulus. Must be given together with `rho_fluid`.
-    rho_fluid : `firedrake.Constant` or `firedrake.Function`, optional
-        Fluid density. Must be given together with `K`.
+    c, K, rho_fluid : optional
+        Passed through to `velocity_fluid` to determine the fluid wave
+        velocity.
 
     Returns
     -------
@@ -51,20 +81,7 @@ def build_acoustic_form(
         If `c` is given together with `K` or `rho_fluid` (ambiguous), or if
         only one of `K`/`rho_fluid` is given (incomplete).
     """
-
-    if c is not None and (K is not None or rho_fluid is not None):
-        raise ValueError(
-            "Ambiguous formulation. Insert 'bulk_modulus' and 'density_fluid' "
-            "or just 'c'."
-        )
-    if c is None:
-        if K is not None and rho_fluid is not None:
-            c = sqrt(K / rho_fluid)
-        elif K is not None or rho_fluid is not None:
-            raise ValueError("Insert both values 'bulk_modulus' and 'density_fluid'.")
-        else:
-            c = wave.c
-
+    c = velocity_fluid(c, K, rho_fluid, default=wave.c)
     dt = wave.dt
 
     m1 = (
@@ -123,15 +140,15 @@ def build_acoustic_form(
 
 
 def construct_solver_or_matrix_no_pml(wave):
-    """Build the Firedrake solver for the acoustic wave, without PML,
-    with typical BCs, NRBCs or HABCs.
+    """Build the Firedrake solver for the acoustic wave, without PML.
+
+    Handles typical BCs, NRBCs or HABCs.
 
     Parameters
     ----------
     wave : `acoustic_wave.AcousticWave`
         An instance of the :class:`~spyro.solvers.acoustic_wave.AcousticWave`.
     """
-
     V = wave.function_space
     quad_rule = wave.quadrature_rule
 

--- a/spyro/solvers/acoustic_solver_construction_no_pml.py
+++ b/spyro/solvers/acoustic_solver_construction_no_pml.py
@@ -1,20 +1,137 @@
-"""Constructs Firedrake solver for the acosutic wave with typical BCs, NRBCs or HABCs."""
+"""Constructs Firedrake solver for the acoustic wave with typical BCs, 
+NRBCs or HABCs."""
 
 import firedrake as fire
-from firedrake import ds, dx, dot, grad
+from firedrake import ds, dx, dot, grad, sqrt
 from ..utils.typing import AbsorbingBCsType
 
 
-def construct_solver_or_matrix_no_pml(wave):
-    """Builds solver operators for wave propagator with typical BCs, NRBCs or HABCs.
+def build_acoustic_form(
+    wave,
+    u_trial,
+    v_test,
+    u_n,
+    u_nm1,
+    quad_rule,
+    c=None,
+    K=None,
+    rho_fluid=None
+):
+    """Build the weak form of the acoustic wave equation for one time step.
 
-    Doesn't create mass matrices if matrix_free option is on, which it is by default.
+    Parameters
+    ----------
+    wave : `acoustic_wave.AcousticWave`
+        An instance of the :class:`~spyro.solvers.acoustic_wave.AcousticWave`.
+    u_trial : `firedrake.TrialFunction`
+        Trial function for the pressure field at the next time step.
+    v_test : `firedrake.TestFunction`
+        Test function for the pressure field.
+    u_n : `firedrake.Function`
+        Pressure field at the current time step.
+    u_nm1 : `firedrake.Function`
+        Pressure field at the previous time step.
+    quad_rule : dict
+        Quadrature rule for volume integration.
+    c : `firedrake.Constant` or UFL expression, optional
+        Fluid wave speed. Mutually exclusive with `K`/`rho_fluid`.
+    K : `firedrake.Constant` or `firedrake.Function`, optional
+        Fluid bulk modulus. Must be given together with `rho_fluid`.
+    rho_fluid : `firedrake.Constant` or `firedrake.Function`, optional
+        Fluid density. Must be given together with `K`.
+
+    Returns
+    -------
+    form : UFL form
+        The combined weak form (mass + stiffness + source + absorbing terms).
+
+    Raises
+    ------
+    ValueError
+        If `c` is given together with `K` or `rho_fluid` (ambiguous), or if
+        only one of `K`/`rho_fluid` is given (incomplete).
+    """
+
+    if c is not None and (K is not None or rho_fluid is not None):
+        raise ValueError(
+            "Ambiguous formulation. Insert 'bulk_modulus' and 'density_fluid' "
+            "or just 'c'."
+        )
+    if c is None:
+        if K is not None and rho_fluid is not None:
+            c = sqrt(K / rho_fluid)
+        elif K is not None or rho_fluid is not None:
+            raise ValueError("Insert both values 'bulk_modulus' and 'density_fluid'.")
+        else:
+            c = wave.c
+
+    dt = wave.dt
+
+    m1 = (
+        (1 / (c * c))
+        * ((u_trial - 2.0 * u_n + u_nm1) / dt**2)
+        * v_test
+        * dx(**quad_rule)
+    )
+    a = dot(grad(u_n), grad(v_test)) * dx(**quad_rule)
+
+    le = 0.0
+    q = wave.source_expression
+    if q is not None:
+        le += -q * v_test * dx(**quad_rule)
+
+    if wave.abc_active and not wave.abc_get_ref_model:
+        weak_expr_abc = dot((u_n - u_nm1) / dt, v_test)
+
+        f_abc = (1 / c) * weak_expr_abc
+        qr_s = wave.surface_quadrature_rule
+
+        if wave.abc_type == AbsorbingBCsType.HYBRID:
+
+            # NRBC
+            le += wave.cosHig * f_abc * ds(**qr_s)
+
+            # Damping
+            le += (
+                wave.eta_mask
+                * weak_expr_abc
+                * (1 / (c * c))
+                * wave.eta_habc
+                * dx(**quad_rule)
+            )
+
+        else:
+            if wave.absorb_top:
+                le += f_abc * ds(1, **qr_s)
+            if wave.absorb_bottom:
+                le += f_abc * ds(2, **qr_s)
+            if wave.absorb_right:
+                le += f_abc * ds(3, **qr_s)
+            if wave.absorb_left:
+                le += f_abc * ds(4, **qr_s)
+            if wave.dimension == 3:
+                if wave.absorb_front:
+                    le += f_abc * ds(5, **qr_s)
+                if wave.absorb_back:
+                    le += f_abc * ds(6, **qr_s)
+
+    # form = m1 + a - le
+    # Signal for le is + in derivation, see Salas et al (2022)
+    # doi: https://doi.org/10.1016/j.apm.2022.09.014
+    # TODO: Add citation
+    return m1 + a + le
+
+
+def construct_solver_or_matrix_no_pml(wave):
+    """Build the Firedrake solver for the acoustic wave, without PML,
+    with typical BCs, NRBCs or HABCs.
 
     Parameters
     ----------
     wave : `acoustic_wave.AcousticWave`
         An instance of the :class:`~spyro.solvers.acoustic_wave.AcousticWave`.
     """
+
     V = wave.function_space
     quad_rule = wave.quadrature_rule
 
@@ -32,66 +149,18 @@ def construct_solver_or_matrix_no_pml(wave):
     wave.current_time = 0.0
     dt = wave.dt
 
-    # -------------------------------------------------------
-    m1 = (
-        (1 / (wave.c * wave.c))
-        * ((u - 2.0 * u_n + u_nm1) / dt**2)
-        * v
-        * dx(**quad_rule)
-    )
-    a = dot(grad(u_n), grad(v)) * dx(**quad_rule)  # explicit
+    form = build_acoustic_form(wave, u, v, u_n, u_nm1, quad_rule)
 
-    le = 0.0
-    q = wave.source_expression
-    if q is not None:
-        le += - q * v * dx(**quad_rule)
-
-    if wave.abc_active and not wave.abc_get_ref_model:
-        weak_expr_abc = dot((u_n - u_nm1) / dt, v)
-
-        f_abc = (1 / wave.c) * weak_expr_abc
-        qr_s = wave.surface_quadrature_rule
-
-        if wave.abc_type == AbsorbingBCsType.HYBRID:
-
-            # NRBC
-            le += wave.cosHig * f_abc * ds(**qr_s)
-
-            # Damping
-            le += wave.eta_mask * weak_expr_abc * \
-                (1 / (wave.c * wave.c)) * \
-                wave.eta_habc * dx(**quad_rule)
-
-        else:
-            if wave.absorb_top:
-                le += f_abc*ds(1, **qr_s)
-            if wave.absorb_bottom:
-                le += f_abc*ds(2, **qr_s)
-            if wave.absorb_right:
-                le += f_abc*ds(3, **qr_s)
-            if wave.absorb_left:
-                le += f_abc*ds(4, **qr_s)
-            if wave.dimension == 3:
-                if wave.absorb_front:
-                    le += f_abc*ds(5, **qr_s)
-                if wave.absorb_back:
-                    le += f_abc*ds(6, **qr_s)
-
-    # form = m1 + a - le
-    # Signal for le is + in derivation, see Salas et al (2022)
-    # doi: https://doi.org/10.1016/j.apm.2022.09.014
-    # TODO: Add citation
-    form = m1 + a + le
     wave.rhs = fire.rhs(form)
     wave.lhs = fire.lhs(form)
     wave.source_function = fire.Cofunction(V.dual())
 
     lin_var = fire.LinearVariationalProblem(
-        wave.lhs,
-        wave.rhs + wave.source_function,
-        u_np1, constant_jacobian=True)
+        wave.lhs, wave.rhs + wave.source_function, u_np1, constant_jacobian=True
+    )
     solver_parameters = dict(wave.solver_parameters)
     solver_parameters["mat_type"] = "matfree"
     wave.solver = fire.LinearVariationalSolver(
-        lin_var, solver_parameters=solver_parameters,
+        lin_var,
+        solver_parameters=solver_parameters,
     )

--- a/spyro/solvers/elastic_wave/forms.py
+++ b/spyro/solvers/elastic_wave/forms.py
@@ -1,11 +1,88 @@
-from firedrake import (Cofunction, Constant, LinearVariationalProblem,
-                       LinearVariationalSolver, div, dot, dx, grad, inner,
-                       lhs, rhs, TestFunction, TrialFunction)
+"""Constructs Firedrake solver for the isotropic elastic wave with
+typical BCs, NRBCs or HABCs.
+"""
+
+from firedrake import (
+    Cofunction,
+    Constant,
+    LinearVariationalProblem,
+    LinearVariationalSolver,
+    div,
+    dot,
+    dx,
+    grad,
+    inner,
+    lhs,
+    rhs,
+    TestFunction,
+    TrialFunction,
+)
 
 from .local_abc import local_abc_form
 
 
+def build_elastic_form(wave, u_trial, v_test, u_n, u_nm1, quad_rule):
+    """Build the weak form of the isotropic elastic wave equation for one
+    time step.
+
+    Parameters
+    ----------
+    wave : `elastic_wave.IsotropicWave` or
+        `acoustic_elastic_wave.AcousticElasticWave`
+        An instance exposing `rho`, `lmbda`, `mu`, `dt`, `body_forces`,
+        and the absorbing-boundary attributes consumed by
+        `local_abc_form`.
+    u_trial : `firedrake.TrialFunction`
+        Trial function for the displacement field at the next time step.
+    v_test : `firedrake.TestFunction`
+        Test function for the displacement field.
+    u_n : `firedrake.Function`
+        Displacement field at the current time step.
+    u_nm1 : `firedrake.Function`
+        Displacement field at the previous time step.
+    quad_rule : dict
+        Quadrature rule for volume integration.
+
+    Returns
+    -------
+    form : UFL form
+        The combined weak form (mass + stiffness - source - absorbing
+        terms).
+    """
+
+    dt = Constant(wave.dt)
+    rho = wave.rho
+    lmbda = wave.lmbda
+    mu = wave.mu
+
+    F_m = (rho / (dt**2)) * dot(u_trial - 2 * u_n + u_nm1, v_test) * dx(**quad_rule)
+
+    eps = lambda v: 0.5 * (grad(v) + grad(v).T)
+    F_k = lmbda * div(u_n) * div(v_test) * dx(**quad_rule) + 2 * mu * inner(
+        eps(u_n), eps(v_test)
+    ) * dx(**quad_rule)
+
+    F_s = 0
+    b = wave.body_forces
+    if b is not None:
+        F_s += dot(b, v_test) * dx(**quad_rule)
+
+    F_t = local_abc_form(wave)
+
+    return F_m + F_k - F_s - F_t
+
+
 def isotropic_elastic_without_pml(wave):
+    """Build the Firedrake solver for the isotropic elastic wave, without
+    PML.
+
+    Parameters
+    ----------
+    wave : `elastic_wave.IsotropicWave`
+        An instance of the
+        :class:`~spyro.solvers.elastic_wave.isotropic_wave.IsotropicWave`.
+    """
+
     V = wave.function_space
     quad_rule = wave.quadrature_rule
 
@@ -15,25 +92,7 @@ def isotropic_elastic_without_pml(wave):
     u_nm1 = wave.u_nm1
     u_n = wave.u_n
 
-    dt = Constant(wave.dt)
-    rho = wave.rho
-    lmbda = wave.lmbda
-    mu = wave.mu
-
-    F_m = (rho/(dt**2))*dot(u - 2*u_n + u_nm1, v)*dx(**quad_rule)
-
-    eps = lambda v: 0.5*(grad(v) + grad(v).T)
-    F_k = lmbda*div(u_n)*div(v)*dx(**quad_rule) \
-        + 2*mu*inner(eps(u_n), eps(v))*dx(**quad_rule)
-
-    F_s = 0
-    b = wave.body_forces
-    if b is not None:
-        F_s += dot(b, v)*dx(**quad_rule)
-
-    F_t = local_abc_form(wave)
-
-    F = F_m + F_k - F_s - F_t
+    F = build_elastic_form(wave, u, v, u_n, u_nm1, quad_rule)
 
     wave.lhs = lhs(F)
     wave.rhs = rhs(F)
@@ -49,10 +108,9 @@ def isotropic_elastic_without_pml(wave):
     )
     solver_parameters = dict(wave.solver_parameters)
     solver_parameters["mat_type"] = "matfree"
-    wave.solver = LinearVariationalSolver(
-        lin_var, solver_parameters=solver_parameters
-    )
+    wave.solver = LinearVariationalSolver(lin_var, solver_parameters=solver_parameters)
 
 
 def isotropic_elastic_with_pml():
+    """Not yet implemented."""
     raise NotImplementedError

--- a/spyro/solvers/elastic_wave/forms.py
+++ b/spyro/solvers/elastic_wave/forms.py
@@ -1,5 +1,6 @@
-"""Constructs Firedrake solver for the isotropic elastic wave with
-typical BCs, NRBCs or HABCs.
+"""Constructs Firedrake solver for the isotropic elastic wave.
+
+Handles typical BCs, NRBCs or HABCs.
 """
 
 from firedrake import (
@@ -22,8 +23,7 @@ from .local_abc import local_abc_form
 
 
 def build_elastic_form(wave, u_trial, v_test, u_n, u_nm1, quad_rule):
-    """Build the weak form of the isotropic elastic wave equation for one
-    time step.
+    """Build the weak form of the isotropic elastic wave equation.
 
     Parameters
     ----------
@@ -49,7 +49,6 @@ def build_elastic_form(wave, u_trial, v_test, u_n, u_nm1, quad_rule):
         The combined weak form (mass + stiffness - source - absorbing
         terms).
     """
-
     dt = Constant(wave.dt)
     rho = wave.rho
     lmbda = wave.lmbda
@@ -73,8 +72,9 @@ def build_elastic_form(wave, u_trial, v_test, u_n, u_nm1, quad_rule):
 
 
 def isotropic_elastic_without_pml(wave):
-    """Build the Firedrake solver for the isotropic elastic wave, without
-    PML.
+    """Build the Firedrake solver for the isotropic elastic wave.
+
+    Built without PML.
 
     Parameters
     ----------
@@ -82,7 +82,6 @@ def isotropic_elastic_without_pml(wave):
         An instance of the
         :class:`~spyro.solvers.elastic_wave.isotropic_wave.IsotropicWave`.
     """
-
     V = wave.function_space
     quad_rule = wave.quadrature_rule
 


### PR DESCRIPTION
To build the coupled fluid-solid solver, the acoustic and elastic weak-form constructors needed to be adapted so that only the weak form (matrices) is built, without invoking their respective solvers. Both were therefore split into two functions each, one that builds the form and one that assembles the solver, so that none of the existing simulation modes are broken (acoustic-only, elastic-only, and the coupled acoustic-elastic solver).

**Changes:**

- Split `build_acoustic_form` / `construct_solver_or_matrix_no_pml` and `build_elastic_form` / `isotropic_elastic_no_pml` into separate form-building and solver-construction functions;
- Added support for specifying the acoustic wave speed via the fluid bulk modulus (`K`) and density (`rho_fluid`) instead of `c` directly, since these parameters will be needed for the future interface-continuity analysis in the coupled solver. `c` and `K`/`rho_fluid` are mutually exclusive; passing both, or only one of `K`/`rho_fluid`, raises a clear `ValueError`;
- General formatting and docstring cleanup. Behavior is otherwise unchanged.

 **Follow-up:**

A future PR will rename the solid density attribute from `rho` to `rho_solid`, for clarity and consistency with the fluid-side `rho_fluid` naming.